### PR TITLE
refactor: inline FetusPhoto click flag

### DIFF
--- a/Scripts/Gameplay/FetusPhoto.gd
+++ b/Scripts/Gameplay/FetusPhoto.gd
@@ -5,7 +5,7 @@ signal dialog_done
 @export var dialog_id  : String = "fetus_dialog"
 @export var center_pos : Vector2                 # set by StageController
 
-@onready var _clicked : bool = false
+var _clicked: bool = false
 
 func _ready() -> void:
 	input_pickable = true                        # receive mouse clicks


### PR DESCRIPTION
## Summary
- inline FetusPhoto `_clicked` flag with regular variable, removing deferred `@onready`

## Testing
- `godot3 --headless --quit` *(fails: Can't open project config_version 5)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb447c948327ad751a7fd4681dd1