### PR TITLE
Refactor dialogue hooks to use autoload

### DIFF
--- a/Scripts/Gameplay/Critter.gd
+++ b/Scripts/Gameplay/Critter.gd
@@ -112,18 +112,10 @@ func _trigger() -> void:
 		if DEBUG: print("[Critter] (no one_liner_id) – only play trigger anim")
 		return
 
-	var dm : Node = get_tree().get_root().get_node_or_null("DialogueManager")
-	if dm == null:
-		push_warning("[Critter] DialogueManager autoload not found at /root/DialogueManager")
-		return
-	if not dm.has_method("start"):
-		push_warning("[Critter] DialogueManager is missing method 'start(String)'")
-		return
-
-	# Connect to know when dialogue ends (one-shot).
-	if DEBUG: print("[Critter] → starting one-liner id='", one_liner_id, "'")
-	dm.connect("dialogue_finished", Callable(self, "_on_dialogue_finished"), CONNECT_ONE_SHOT)
-	dm.call("start", one_liner_id)
+        # Connect to know when dialogue ends (one-shot).
+        if DEBUG: print("[Critter] → starting one-liner id='", one_liner_id, "'")
+        DialogueManager.connect("dialogue_finished", Callable(self, "_on_dialogue_finished"), CONNECT_ONE_SHOT)
+        DialogueManager.start(one_liner_id)
 
 func _on_trigger_anim_finished(_anim:String) -> void:
 	# If dialogue did not run, allow movement again

--- a/Scripts/Gameplay/Photo.gd
+++ b/Scripts/Gameplay/Photo.gd
@@ -157,16 +157,8 @@ func _start_dialogue_if_possible() -> void:
 		if DEBUG: print("[Photo] editor hint – skip dialogue")
 		return
 
-	var dm : Node = get_tree().get_root().get_node_or_null("DialogueManager")
-	if dm == null:
-		push_warning("[Photo] DialogueManager autoload not found at /root/DialogueManager")
-		return
-	if not dm.has_method("start"):
-		push_warning("[Photo] DialogueManager is missing method 'start(String)'")
-		return
-
-	if DEBUG: print("[Photo] → starting dialogue id='", dialog_id, "'")
-	dm.call("start", dialog_id)
+        if DEBUG: print("[Photo] → starting dialogue id='", dialog_id, "'")
+        DialogueManager.start(dialog_id)
 
 # ───────────────────────────
 #  Helpers


### PR DESCRIPTION
## Summary
- replace node lookup with autoload `DialogueManager` in Photo.gd
- use autoload `DialogueManager` in Critter.gd and drop redundant checks

## Testing
- `godot3 --headless --path . --quit` *(fails: project requires newer config version)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb4f86108327a667a39407218743