### PR TITLE
Remove unused photo helper functions

### DIFF
--- a/Scripts/Gameplay/Photo.gd
+++ b/Scripts/Gameplay/Photo.gd
@@ -182,12 +182,6 @@ func _nearest_slot() -> Area2D:
 				best   = s
 	return best
 
-func _find_slot_by_idx(idx: int) -> Area2D:
-	for s in get_tree().get_nodes_in_group("memory_slots"):
-		if s.slot_idx == idx:
-			return s
-	return null
-
 # ───────────────────────────
 #  Cleanup & seal
 # ───────────────────────────
@@ -212,7 +206,3 @@ func _attach_random_tape() -> void:
 
 	var half_h : float = sprite.texture.get_height() * sprite.scale.y * 0.5
 	tape.position = Vector2(0, -half_h)
-
-func _on_seal(_p: Photo) -> void:
-	is_sealed = true
-	_attach_random_tape()


### PR DESCRIPTION
## Summary
- delete unused `_find_slot_by_idx` and `_on_seal` helpers from `Photo.gd`
- leave photo script cleaner with no dangling seal handler

## Testing
- `gdformat --check Scripts/Gameplay/Photo.gd` *(fails: would reformat)*
- `gdlint Scripts/Gameplay/Photo.gd` *(fails: definition out of order in global scope)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb4fc5d88327be7a447a475d1f51