### PR TITLE
Use Godot debug flag for debug logs

### DIFF
--- a/Scripts/Gameplay/Critter.gd
+++ b/Scripts/Gameplay/Critter.gd
@@ -16,7 +16,7 @@ var _view : Rect2
 var _dir  : Vector2 = Vector2.ZERO
 var _action_name : String
 var _triggered   : bool = false
-const DEBUG := true
+const DEBUG := OS.is_debug_build()
 
 # ───────── READY ─────────
 func _ready() -> void:

--- a/Scripts/Gameplay/Photo.gd
+++ b/Scripts/Gameplay/Photo.gd
@@ -32,7 +32,7 @@ var is_sealed : bool    = false
 static var current_drag    : Photo = null                # exclusive-drag lock
 static var _unused_tapes   : Array[Texture2D] = []       # shared between all photos
 
-const DEBUG := true
+const DEBUG := OS.is_debug_build()
 
 # tape pool  (add the exact filenames you have in Assets/Tape/)
 const TAPE_TEXTURES : Array[Texture2D] = [


### PR DESCRIPTION
## Summary
- Derive DEBUG constant from `OS.is_debug_build()` in Critter and Photo scripts so debug prints only run on debug builds.

## Testing
- `godot3-server -s test_debug.gd`


------
https://chatgpt.com/codex/tasks/task_e_6898cb533d548327a2dc44b239c32679