### PR TITLE
Remove onready annotation from clicked flag

### DIFF
--- a/Scripts/Gameplay/FetusPhoto.gd
+++ b/Scripts/Gameplay/FetusPhoto.gd
@@ -5,7 +5,7 @@ signal dialog_done
 @export var dialog_id  : String = "fetus_dialog"
 @export var center_pos : Vector2                 # set by StageController
 
-@onready var _clicked : bool = false
+var _clicked : bool = false
 
 func _ready() -> void:
 	input_pickable = true                        # receive mouse clicks


### PR DESCRIPTION
## Summary
- Replace the `@onready` declaration of `_clicked` with a normal variable in `FetusPhoto.gd`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb5ee8b083279832b6f7a6688d84