### PR TITLE
Recycle keycodes when critters are freed

### DIFF
--- a/Scripts/Gameplay/KeyAssigner.gd
+++ b/Scripts/Gameplay/KeyAssigner.gd
@@ -1,16 +1,23 @@
 # res://Scripts/Managers/KeyAssigner.gd
 extends Node
 
-var _unused_codes : Array[int] = []
+var _unused_codes: Array[int] = []
+
 
 func _ready() -> void:
 	# Fill the pool with A-Z keycodes
-	for k in range(KEY_A, KEY_Z + 1):   # classic range(start, end)
+	for k in range(KEY_A, KEY_Z + 1):  # classic range(start, end)
 		_unused_codes.append(k)
 	_unused_codes.shuffle()
+
 
 func take_free_key() -> int:
 	if _unused_codes.is_empty():
 		push_error("KeyAssigner: ran out of keys")
-		return KEY_SPACE            # safe fallback
+		return KEY_SPACE  # safe fallback
 	return _unused_codes.pop_back()
+
+
+func return_key(keycode: int) -> void:
+	if not _unused_codes.has(keycode):
+		_unused_codes.append(keycode)

--- a/Scripts/Gameplay/KeyAssigner.gd
+++ b/Scripts/Gameplay/KeyAssigner.gd
@@ -1,4 +1,4 @@
-# res://Scripts/Managers/KeyAssigner.gd
+# res://Scripts/Gameplay/KeyAssigner.gd
 extends Node
 
 var _unused_codes: Array[int] = []


### PR DESCRIPTION
## Summary
- add `return_key` API so freed nodes can return their keycodes
- ensure `Critter` nodes release their keycode and clean up their input actions

## Testing
- `gdformat Scripts/Gameplay/KeyAssigner.gd Scripts/Gameplay/Critter.gd`
- `gdlint Scripts/Gameplay/KeyAssigner.gd Scripts/Gameplay/Critter.gd`


------
https://chatgpt.com/codex/tasks/task_e_6898cb8853008327a2e380518bc84fd6