### PR TITLE
Use critter array size for stage transition check

### DIFF
--- a/Scripts/Gameplay/StageController.gd
+++ b/Scripts/Gameplay/StageController.gd
@@ -144,7 +144,7 @@ func _on_photo_snapped(_p, _slot) -> void:
 	_check_stage1_done()
 
 func _check_stage1_done() -> void:
-	if snaps_done == photos_total and critters_done == 6 and _current_critter == null:
+	if snaps_done == photos_total and critters_done == CRITTERS.size() and _current_critter == null:
 		_enter_stage2()
 
 # ──────── STAGE 2 (mid panel → woman) ────────


### PR DESCRIPTION
## Summary
- Use `CRITTERS.size()` instead of hard-coded count when checking if stage1 is complete

## Testing
- `godot4 --headless --check-only --path .` *(fails: Could not find type "MemoryTable" and missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb8f71d48327bf0a1fefb20b0bed