### PR TITLE
Set default slot config paths for stage controller

### DIFF
--- a/Scripts/Gameplay/StageController.gd
+++ b/Scripts/Gameplay/StageController.gd
@@ -25,8 +25,8 @@ extends Node
 @export var mid_stage_panel     : PackedScene               # “Now she is ready …”
 @export var memory_table        : MemoryTable
 @export var alt_intro_scene     : PackedScene
-@export var easy_slots_json     : String
-@export var hard_slots_json     : String
+@export var easy_slots_json     : String = "res://Data/SlotConfigs/easy.json"
+@export var hard_slots_json     : String = "res://Data/SlotConfigs/hard.json"
 @export var heartbeat_sfx       : String = "fetusHeartbeat"
 
 # ───────── ONREADY MARKERS ─────────


### PR DESCRIPTION
## Summary
- default StageController slot configs to easy and hard JSON paths

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb919b308327b17d9c15da025702