### PR TITLE
Refactor memory slot init to use scene properties

### DIFF
--- a/Scripts/Gameplay/MemorySlot.gd
+++ b/Scripts/Gameplay/MemorySlot.gd
@@ -1,12 +1,6 @@
 extends Area2D
 @export var memory_id : String = ""
-@onready var sprite := $Sprite2D
 @export var slot_idx : int = 0      # 0 = unassigned, give each slot a unique index
-
-func _ready():
-	add_to_group("memory_slots")
-	collision_layer = 2       # slot layer
-	collision_mask  = 0       # doesn’t detect physics, only overlaps
 	
 func get_circle_texture() -> Texture2D:
 	return MemoryPool.table.memory_to_circle_tex.get(memory_id, null)

--- a/Scripts/Gameplay/Photo.gd
+++ b/Scripts/Gameplay/Photo.gd
@@ -49,8 +49,7 @@ const TAPE_TEXTURES : Array[Texture2D] = [
 #  Ready
 # ───────────────────────────
 func _ready() -> void:
-	set_pickable(true)
-	add_to_group("photos")
+        set_pickable(true)
 
 # ───────────────────────────
 #  Input (drag / drop)


### PR DESCRIPTION
## Summary
- remove unused sprite handle from MemorySlot
- rely on scene config for MemorySlot groups/layers
- drop Photo's runtime group registration

## Testing
- `gdlint Scripts/Gameplay/MemorySlot.gd Scripts/Gameplay/Photo.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb92c0948327b83c6dc137401bed