### PR TITLE
Remove onready annotation from clicked flag

### DIFF
--- a/Scripts/Gameplay/FetusPhoto.gd
+++ b/Scripts/Gameplay/FetusPhoto.gd
@@ -5,7 +5,7 @@ signal dialog_done
 @export var dialog_id  : String = "fetus_dialog"
 @export var center_pos : Vector2                 # set by StageController
 
-@onready var _clicked : bool = false
+var _clicked: bool = false
 
 func _ready() -> void:
 	input_pickable = true                        # receive mouse clicks


### PR DESCRIPTION
## Summary
- Initialize `_clicked` without the `@onready` annotation in `FetusPhoto.gd`

## Testing
- `godot3 --headless --check-only --path .` *(fails: project requires a newer engine version)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb94629883278eded8aaa41f3da7