### PR TITLE
Use debug build checks for debug logging

### DIFF
--- a/Scripts/Gameplay/Critter.gd
+++ b/Scripts/Gameplay/Critter.gd
@@ -16,7 +16,7 @@ var _view : Rect2
 var _dir  : Vector2 = Vector2.ZERO
 var _action_name : String
 var _triggered   : bool = false
-const DEBUG := true
+const DEBUG := OS.is_debug_build()
 
 # ───────── READY ─────────
 func _ready() -> void:

--- a/Scripts/Gameplay/Photo.gd
+++ b/Scripts/Gameplay/Photo.gd
@@ -32,7 +32,7 @@ var is_sealed : bool    = false
 static var current_drag    : Photo = null                # exclusive-drag lock
 static var _unused_tapes   : Array[Texture2D] = []       # shared between all photos
 
-const DEBUG := true
+const DEBUG := OS.is_debug_build()
 
 # tape pool  (add the exact filenames you have in Assets/Tape/)
 const TAPE_TEXTURES : Array[Texture2D] = [


### PR DESCRIPTION
## Summary
- conditionally enable debug logging in Critter using `OS.is_debug_build()`
- conditionally enable debug logging in Photo using `OS.is_debug_build()`

## Testing
- `gdlint Scripts/Gameplay/Critter.gd Scripts/Gameplay/Photo.gd` *(fails: Definition out of order in global scope)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb95e240832794bb2820d75c4a3b