### PR TITLE
Remove unused shard callbacks

### DIFF
--- a/Scripts/Gameplay/WomanPhoto.gd
+++ b/Scripts/Gameplay/WomanPhoto.gd
@@ -30,8 +30,6 @@ func _ready() -> void:
 
 	for i in range(_container.get_child_count()):
 		var shard : Area2D = _container.get_child(i)
-		shard.area_entered.connect(_on_shard_entered.bind(i))
-		shard.area_exited .connect(_on_shard_exited .bind(i))
 		shard.input_event .connect(_on_shard_input  .bind(i))
 
 		var overlay := shard.get_node("CrackOverlay") as CanvasItem
@@ -92,10 +90,6 @@ func _process(_delta:float) -> void:
 		lbl.scale        = Vector2.ONE * lerp(1.0, hover_scale_factor, t)
 		lbl.modulate     = base_tint.lerp(hover_tint, t)
 		lbl.modulate.a   = t * fade_strength
-
-# ───────────── shard callbacks ─────────────
-func _on_shard_entered(_area:Area2D, _idx:int) -> void: pass
-func _on_shard_exited (_area:Area2D, _idx:int) -> void: pass
 
 func _on_shard_input(_vp, event:InputEvent, _shape_idx:int, idx:int) -> void:
 	if event is InputEventMouseButton and event.pressed:


### PR DESCRIPTION
## Summary
- drop unused shard enter/exit signal connections
- remove empty `_on_shard_entered` and `_on_shard_exited` callbacks

## Testing
- `godot3-server --headless --check Scripts/Gameplay/WomanPhoto.gd` *(fails: project uses newer engine config version)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb9742e8832788710a29c9b3d84f