### PR TITLE
fix: correct KeyAssigner path comment

### DIFF
--- a/Scripts/Gameplay/KeyAssigner.gd
+++ b/Scripts/Gameplay/KeyAssigner.gd
@@ -1,4 +1,4 @@
-# res://Scripts/Managers/KeyAssigner.gd
+# res://Scripts/Gameplay/KeyAssigner.gd
 extends Node
 
 var _unused_codes : Array[int] = []


### PR DESCRIPTION
## Summary
- fix KeyAssigner header path to match its actual location

## Testing
- `godot3 --headless --quit` *(fails: Can't open project, config_version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb98482483279f11694553e2baf9