### PR TITLE
Remove critter input action on cleanup

### DIFF
--- a/Scripts/Gameplay/Critter.gd
+++ b/Scripts/Gameplay/Critter.gd
@@ -139,6 +139,12 @@ func _on_dialogue_finished(last_id: String) -> void:
 	_triggered = false
 	sprite.play("move")
 	emit_signal("dialogue_done")
+	if InputMap.has_action(_action_name):
+		InputMap.erase_action(_action_name)
+
+func _exit_tree() -> void:
+	if InputMap.has_action(_action_name):
+		InputMap.erase_action(_action_name)
 
 # ───────── DEBUG DRAW ─────────
 func _draw() -> void:


### PR DESCRIPTION
## Summary
- remove critter-specific input action once dialogue completes
- ensure input action is cleared when critter exits the scene

## Testing
- `gdlint Scripts/Gameplay/Critter.gd` *(fails: Definition out of order in global scope (class-definitions-order))*

------
https://chatgpt.com/codex/tasks/task_e_6898cb5d1658832780a5abc6b1444429