### PR TITLE
chore: remove unused origin path from photo

### DIFF
--- a/Scripts/Gameplay/Photo.gd
+++ b/Scripts/Gameplay/Photo.gd
@@ -16,7 +16,6 @@ signal drag_ended(photo)
 @export var memory_id      : String           = ""
 @export var snap_radius    : float            = 30.0
 @export var allowed_slots  : PackedInt32Array = []
-@export_node_path("Node2D") var origin_path  : NodePath
 
 # ───────────────────────────
 #  Internal state


### PR DESCRIPTION
## Summary
- remove unused `origin_path` inspector field from `Photo.gd`
- keep `_on_seal` as `seal_done` is still emitted by `MemoryCircle`

## Testing
- `gdlint Scripts/Gameplay/Photo.gd` *(fails: Definition out of order in global scope)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb5c54b48327b80b852faa6fed2b