### PR TITLE
Refactor stages into state machine

### DIFF
--- a/Scripts/Gameplay/StageController.gd
+++ b/Scripts/Gameplay/StageController.gd
@@ -5,43 +5,9 @@ extends Node
 #   IntroState  → Stage1State → Stage2State → Stage3State → Stage4State → EndState
 #   Each state handles its own setup and emits `transition_to` when ready to move
 #   to the next step. StageController swaps states and keeps common references.
-#
 
-# ───────── EXPORTS ─────────
-@export_node_path("Node")        var gameplay_path      : NodePath
-@export_node_path("CanvasLayer") var overlay_path       : NodePath
-@export_node_path("Node")        var stack_path         : NodePath
-@export_node_path("Marker2D")    var woman_spawn_path   : NodePath
-@export_node_path("Marker2D")    var river_spawn_path   : NodePath
-@export_node_path("Marker2D")    var fetus_spawn_path   : NodePath
-@export_node_path("Marker2D") 	var fetus_centre_path : NodePath
-@export_node_path("Marker2D")    var woman_target_path  : NodePath
-
-@export var woman_lead_in_scene : PackedScene
-@export var mid_stage_panel     : PackedScene               # “Now she is ready …”
-@export var memory_table        : MemoryTable
-@export var alt_intro_scene     : PackedScene
-@export var easy_slots_json     : String
-@export var hard_slots_json     : String
-@export var heartbeat_sfx       : String = "fetusHeartbeat"
-
-# ───────── ONREADY MARKERS ─────────
-@onready var _woman_spawn : Marker2D = get_node_or_null(woman_spawn_path)
-@onready var _river_pos   : Marker2D = get_node_or_null(river_spawn_path)
-@onready var _fetus_spawn : Marker2D = get_node_or_null(fetus_spawn_path)
-@onready var _fetus_centre : Marker2D = get_node_or_null(fetus_centre_path)
-@onready var _woman_target: Marker2D = get_node_or_null(woman_target_path)
-
-# ───────── STATE ─────────
+# ───────── STATE ENUM ─────────
 enum Stage { INTRO, STAGE1, STAGE2, STAGE3, STAGE4, END }
-var stage : Stage = Stage.INTRO
-
-var gameplay : Node        = null
-var overlay  : CanvasLayer = null
-var woman    : Node = null
-var fetus    : Node = null
-
-var current_state : Node = null
 
 # ───────── PRELOADS ─────────
 const PARENT_PANEL     := preload("res://Scenes/Overlays/ParentChoicePanel.tscn")
@@ -51,7 +17,7 @@ const WOMAN_SCENE      := preload("res://Scenes/WomanPhoto.tscn")
 const FETUS_SCENE      := preload("res://Scenes/FetusPhoto.tscn")
 const RIVER_SCENE      := preload("res://Scenes/River.tscn")  # Area2D with cleanup_complete
 
-# ───────── STATES ─────────
+# ───────── STATE CLASSES ─────────
 const IntroState  = preload("res://Scripts/Gameplay/States/IntroState.gd")
 const Stage1State = preload("res://Scripts/Gameplay/States/Stage1State.gd")
 const Stage2State = preload("res://Scripts/Gameplay/States/Stage2State.gd")
@@ -59,49 +25,89 @@ const Stage3State = preload("res://Scripts/Gameplay/States/Stage3State.gd")
 const Stage4State = preload("res://Scripts/Gameplay/States/Stage4State.gd")
 const EndState    = preload("res://Scripts/Gameplay/States/EndState.gd")
 
+# ───────── EXPORTS ─────────
+@export_node_path("Node")        var gameplay_path     : NodePath
+@export_node_path("CanvasLayer") var overlay_path      : NodePath
+@export_node_path("Node")        var stack_path        : NodePath
+@export_node_path("Marker2D")    var woman_spawn_path  : NodePath
+@export_node_path("Marker2D")    var river_spawn_path  : NodePath
+@export_node_path("Marker2D")    var fetus_spawn_path  : NodePath
+@export_node_path("Marker2D")    var fetus_centre_path : NodePath
+@export_node_path("Marker2D")    var woman_target_path : NodePath
+
+@export var woman_lead_in_scene : PackedScene
+@export var mid_stage_panel     : PackedScene  # "Now she is ready …"
+@export var memory_table        : MemoryTable
+@export var alt_intro_scene     : PackedScene
+@export var easy_slots_json     : String
+@export var hard_slots_json     : String
+@export var heartbeat_sfx       : String = "fetusHeartbeat"
+
+# ───────── VARIABLES ─────────
+var stage : Stage = Stage.INTRO
+var gameplay : Node        = null
+var overlay  : CanvasLayer = null
+var woman    : Node = null
+var fetus    : Node = null
+var current_state : Node = null
+
+# ───────── ONREADY MARKERS ─────────
+@onready var _woman_spawn  : Marker2D = get_node_or_null(woman_spawn_path)
+@onready var _river_pos    : Marker2D = get_node_or_null(river_spawn_path)
+@onready var _fetus_spawn  : Marker2D = get_node_or_null(fetus_spawn_path)
+@onready var _fetus_centre : Marker2D = get_node_or_null(fetus_centre_path)
+@onready var _woman_target : Marker2D = get_node_or_null(woman_target_path)
+
 # ───────── READY ─────────
 func _ready() -> void:
-	MemoryPool.init_from_table(memory_table)
+        MemoryPool.init_from_table(memory_table)
 
-	gameplay = fetch_node(gameplay_path, "Gameplay") ; gameplay.visible = false
-	overlay  = fetch_node(overlay_path,  "OverlayLayer")
+        gameplay = fetch_node(gameplay_path, "Gameplay")
+        gameplay.visible = false
+        overlay = fetch_node(overlay_path, "OverlayLayer")
 
-	change_state(IntroState.new())
+        change_state(IntroState.new())
 
 func change_state(state: Node) -> void:
-	if current_state:
-			current_state.queue_free()
-	current_state = state
-	add_child(current_state)
-	current_state.transition_to.connect(change_state)
-	if current_state is IntroState:
-			stage = Stage.INTRO
-	elif current_state is Stage1State:
-			stage = Stage.STAGE1
-	elif current_state is Stage2State:
-			stage = Stage.STAGE2
-	elif current_state is Stage3State:
-			stage = Stage.STAGE3
-	elif current_state is Stage4State:
-			stage = Stage.STAGE4
-	elif current_state is EndState:
-			stage = Stage.END
-	current_state.enter(self)
+        if current_state:
+                current_state.queue_free()
+        current_state = state
+        add_child(current_state)
+        current_state.transition_to.connect(change_state)
+        if current_state is IntroState:
+                stage = Stage.INTRO
+        elif current_state is Stage1State:
+                stage = Stage.STAGE1
+        elif current_state is Stage2State:
+                stage = Stage.STAGE2
+        elif current_state is Stage3State:
+                stage = Stage.STAGE3
+        elif current_state is Stage4State:
+                stage = Stage.STAGE4
+        elif current_state is EndState:
+                stage = Stage.END
+        current_state.enter(self)
 
-func apply_slot_cfg(path:String) -> void:
-	var j := JSON.new()
-	if j.parse(FileAccess.get_file_as_string(path)) != OK: return
-	for n in j.data:
-			var ph := get_tree().current_scene.find_child(n, true, false)
-			if ph: ph.allowed_slots = PackedInt32Array(j.data[n])
+func apply_slot_cfg(path: String) -> void:
+        var j := JSON.new()
+        if j.parse(FileAccess.get_file_as_string(path)) != OK:
+                return
+        for n in j.data:
+                var ph := get_tree().current_scene.find_child(n, true, false)
+                if ph:
+                        ph.allowed_slots = PackedInt32Array(j.data[n])
 
 # ──────── helpers ────────
 func clear_overlay() -> void:
-	if overlay == null: return
-	for c in overlay.get_children(): c.queue_free()
+        if overlay == null:
+                return
+        for c in overlay.get_children():
+                c.queue_free()
 
-func fetch_node(path:NodePath, fallback:String) -> Node:
-	if path != NodePath(""):
-			var n := get_node_or_null(path)
-			if n: return n
-	return get_tree().current_scene.find_child(fallback, true, false)
+func fetch_node(path: NodePath, fallback: String) -> Node:
+        if path != NodePath(""):
+                var n := get_node_or_null(path)
+                if n:
+                        return n
+        return get_tree().current_scene.find_child(fallback, true, false)
+

--- a/Scripts/Gameplay/StageController.gd
+++ b/Scripts/Gameplay/StageController.gd
@@ -1,14 +1,10 @@
 # scripts/Gameplay/StageController.gd
 extends Node
 #
-# Flow summary
-#   • parent / difficulty   (unchanged)
-#   • Stage 1  – 6 photos snapped AND 6 critter dialogues done
-#   • Stage 2  – mid panel → woman photo
-#   • Stage 3  – woman shrinks to marker, fetus spawns at FetusSpawn
-#               click fetus → centre + heartbeat + dialogue
-#   • Stage 4  – photos turn gold when dragged over fetus, then drag to river
-#   • Outro
+# State machine overview
+#   IntroState  → Stage1State → Stage2State → Stage3State → Stage4State → EndState
+#   Each state handles its own setup and emits `transition_to` when ready to move
+#   to the next step. StageController swaps states and keeps common references.
 #
 
 # ───────── EXPORTS ─────────
@@ -45,21 +41,7 @@ var overlay  : CanvasLayer = null
 var woman    : Node = null
 var fetus    : Node = null
 
-var snaps_done     : int = 0
-var photos_total   : int = 0
-var critters_done  : int = 0
-
-# critter queue
-const CRITTERS : Array[PackedScene] = [
-	preload("res://Scenes/Critters/CritterJesterka.tscn"),
-	preload("res://Scenes/Critters/CritterBrouk.tscn"),
-	preload("res://Scenes/Critters/CritterList.tscn"),
-	preload("res://Scenes/Critters/CritterSklenenka.tscn"),
-	preload("res://Scenes/Critters/CritterSnek.tscn"),
-	preload("res://Scenes/Critters/CritterKliste.tscn")
-]
-var _queue : Array[PackedScene] = []
-var _current_critter : Node = null
+var current_state : Node = null
 
 # ───────── PRELOADS ─────────
 const PARENT_PANEL     := preload("res://Scenes/Overlays/ParentChoicePanel.tscn")
@@ -69,140 +51,57 @@ const WOMAN_SCENE      := preload("res://Scenes/WomanPhoto.tscn")
 const FETUS_SCENE      := preload("res://Scenes/FetusPhoto.tscn")
 const RIVER_SCENE      := preload("res://Scenes/River.tscn")  # Area2D with cleanup_complete
 
+# ───────── STATES ─────────
+const IntroState  = preload("res://Scripts/Gameplay/States/IntroState.gd")
+const Stage1State = preload("res://Scripts/Gameplay/States/Stage1State.gd")
+const Stage2State = preload("res://Scripts/Gameplay/States/Stage2State.gd")
+const Stage3State = preload("res://Scripts/Gameplay/States/Stage3State.gd")
+const Stage4State = preload("res://Scripts/Gameplay/States/Stage4State.gd")
+const EndState    = preload("res://Scripts/Gameplay/States/EndState.gd")
+
 # ───────── READY ─────────
 func _ready() -> void:
 	MemoryPool.init_from_table(memory_table)
 
-	gameplay = _fetch_node(gameplay_path, "Gameplay") ; gameplay.visible = false
-	overlay  = _fetch_node(overlay_path,  "OverlayLayer")
+	gameplay = fetch_node(gameplay_path, "Gameplay") ; gameplay.visible = false
+	overlay  = fetch_node(overlay_path,  "OverlayLayer")
 
-	var parent := PARENT_PANEL.instantiate()
-	overlay.add_child(parent)
-	parent.parent_chosen.connect(_on_parent_decided)
+	change_state(IntroState.new())
 
-	for ph in get_tree().get_nodes_in_group("photos"):
-		photos_total += 1
-		ph.snapped.connect(_on_photo_snapped)
+func change_state(state: Node) -> void:
+	if current_state:
+			current_state.queue_free()
+	current_state = state
+	add_child(current_state)
+	current_state.transition_to.connect(change_state)
+	if current_state is IntroState:
+			stage = Stage.INTRO
+	elif current_state is Stage1State:
+			stage = Stage.STAGE1
+	elif current_state is Stage2State:
+			stage = Stage.STAGE2
+	elif current_state is Stage3State:
+			stage = Stage.STAGE3
+	elif current_state is Stage4State:
+			stage = Stage.STAGE4
+	elif current_state is EndState:
+			stage = Stage.END
+	current_state.enter(self)
 
-# ──────── PARENT / DIFFICULTY ────────
-func _on_parent_decided(is_parent:bool) -> void:
-	_clear_overlay()
-	if is_parent: _show_alt_intro() 
-	else: _show_difficulty()
-
-func _show_alt_intro() -> void:
-	var alt := alt_intro_scene.instantiate()
-	overlay.add_child(alt)
-	alt.intro_finished.connect(func(): get_tree().quit())
-
-func _show_difficulty() -> void:
-	var d := DIFFICULTY_PANEL.instantiate()
-	overlay.add_child(d)
-	d.difficulty_chosen.connect(_on_diff_selected)
-
-func _on_diff_selected(easy:bool) -> void:
-	_apply_slot_cfg(easy_slots_json if easy else hard_slots_json)
-	_clear_overlay()
-	var intro := INTRO_PANEL.instantiate()
-	overlay.add_child(intro)
-	intro.intro_finished.connect(_enter_stage1)
-
-func _apply_slot_cfg(path:String) -> void:
+func apply_slot_cfg(path:String) -> void:
 	var j := JSON.new()
 	if j.parse(FileAccess.get_file_as_string(path)) != OK: return
 	for n in j.data:
-		var ph := get_tree().current_scene.find_child(n, true, false)
-		if ph: ph.allowed_slots = PackedInt32Array(j.data[n])
-
-# ──────── STAGE 1 ────────
-func _enter_stage1() -> void:
-	stage = Stage.STAGE1
-	gameplay.visible = true
-	CircleBank.reset_all(); CircleBank.show_bank()
-	snaps_done = 0; critters_done = 0
-	_queue = CRITTERS.duplicate(); _queue.shuffle()
-	_spawn_next_critter()
-
-func _spawn_next_critter() -> void:
-	if _current_critter: _current_critter.queue_free()
-	if _queue.is_empty():
-		_current_critter = null
-		_check_stage1_done()
-		return
-	_current_critter = _queue.pop_back().instantiate()
-	get_tree().current_scene.add_child(_current_critter)
-	_current_critter.dialogue_done.connect(_on_critter_done, CONNECT_ONE_SHOT)
-
-func _on_critter_done() -> void:
-	critters_done += 1
-	_spawn_next_critter()        # continue queue
-	_check_stage1_done()
-
-func _on_photo_snapped(_p, _slot) -> void:
-	if stage != Stage.STAGE1: return
-	snaps_done += 1
-	_check_stage1_done()
-
-func _check_stage1_done() -> void:
-	if snaps_done == photos_total and critters_done == 6 and _current_critter == null:
-		_enter_stage2()
-
-# ──────── STAGE 2 (mid panel → woman) ────────
-func _enter_stage2() -> void:
-	stage = Stage.STAGE2
-	_clear_overlay()
-	var mid := mid_stage_panel.instantiate()
-	overlay.add_child(mid)
-	mid.intro_finished.connect(_spawn_woman)
-
-func _spawn_woman() -> void:
-	_clear_overlay()
-	var stack := _fetch_node(stack_path, "PhotoStack")
-	woman = WOMAN_SCENE.instantiate()
-	stack.add_child(woman)
-	woman.global_position = (_woman_spawn.global_position if _woman_spawn else Vector2(150,150))
-	woman.all_words_transformed.connect(_enter_stage3)
-
-# ──────── STAGE 3 (woman shrinks → fetus) ────────
-func _enter_stage3() -> void:
-	stage = Stage.STAGE3
-	var dest := _woman_target.global_position if _woman_target else Vector2(100,100)
-	woman.create_tween().tween_property(woman,"global_position",dest,0.8).set_trans(Tween.TRANS_SINE)
-	woman.create_tween().tween_property(woman,"scale",Vector2.ONE*0.3,0.8)
-
-	await get_tree().create_timer(0.8).timeout
-	fetus = FETUS_SCENE.instantiate()
-	get_tree().current_scene.add_child(fetus)
-	fetus.global_position = (_fetus_spawn.global_position if _fetus_spawn else Vector2.ZERO)
-	fetus.center_pos      = _fetus_centre.global_position
-	AudioManager.play_sfx(heartbeat_sfx)
-	fetus.dialog_done.connect(_enter_stage4)
-
-# ──────── STAGE 4 (gold → river) ────────
-func _enter_stage4() -> void:
-	stage = Stage.STAGE4
-	CircleBank.hide_bank()
-
-	for ph in get_tree().get_nodes_in_group("photos"):
-		if ph.has_method("unlock_for_cleanup"): ph.unlock_for_cleanup()
-
-	var river := RIVER_SCENE.instantiate()
-	get_tree().current_scene.add_child(river)
-	river.global_position = (_river_pos.global_position if _river_pos else Vector2(640,720))
-	river.cleanup_complete.connect(_enter_end)
-
-# ──────── OUTRO ────────
-func _enter_end() -> void:
-	stage = Stage.END
-	DialogueManager.load_tree("outro")
+			var ph := get_tree().current_scene.find_child(n, true, false)
+			if ph: ph.allowed_slots = PackedInt32Array(j.data[n])
 
 # ──────── helpers ────────
-func _clear_overlay() -> void:
+func clear_overlay() -> void:
 	if overlay == null: return
 	for c in overlay.get_children(): c.queue_free()
 
-func _fetch_node(path:NodePath, fallback:String) -> Node:
+func fetch_node(path:NodePath, fallback:String) -> Node:
 	if path != NodePath(""):
-		var n := get_node_or_null(path)
-		if n: return n
+			var n := get_node_or_null(path)
+			if n: return n
 	return get_tree().current_scene.find_child(fallback, true, false)

--- a/Scripts/Gameplay/States/EndState.gd
+++ b/Scripts/Gameplay/States/EndState.gd
@@ -1,0 +1,7 @@
+# scripts/Gameplay/States/EndState.gd
+extends StageState
+
+# Loads the outro dialogue.
+
+func enter(_controller: Node) -> void:
+	DialogueManager.load_tree('outro')

--- a/Scripts/Gameplay/States/IntroState.gd
+++ b/Scripts/Gameplay/States/IntroState.gd
@@ -1,0 +1,34 @@
+# scripts/Gameplay/States/IntroState.gd
+extends StageState
+
+# Handles parent and difficulty selection.
+# Transition: IntroState -> Stage1State.
+
+const Stage1State = preload('res://Scripts/Gameplay/States/Stage1State.gd')
+
+func enter(controller: Node) -> void:
+	var parent := controller.PARENT_PANEL.instantiate()
+	controller.overlay.add_child(parent)
+	parent.parent_chosen.connect(func(is_parent: bool):
+		controller.clear_overlay()
+		if is_parent:
+			var alt := controller.alt_intro_scene.instantiate()
+			controller.overlay.add_child(alt)
+			alt.intro_finished.connect(func(): controller.get_tree().quit())
+		else:
+			_show_difficulty(controller)
+	)
+
+func _show_difficulty(controller: Node) -> void:
+	var d := controller.DIFFICULTY_PANEL.instantiate()
+	controller.overlay.add_child(d)
+	d.difficulty_chosen.connect(func(easy: bool):
+		var cfg := controller.easy_slots_json if easy else controller.hard_slots_json
+		controller.apply_slot_cfg(cfg)
+		controller.clear_overlay()
+		var intro := controller.INTRO_PANEL.instantiate()
+		controller.overlay.add_child(intro)
+		intro.intro_finished.connect(func():
+			transition_to.emit(Stage1State.new())
+		)
+	)

--- a/Scripts/Gameplay/States/Stage1State.gd
+++ b/Scripts/Gameplay/States/Stage1State.gd
@@ -1,0 +1,54 @@
+# scripts/Gameplay/States/Stage1State.gd
+extends StageState
+
+# Manages photo snaps and critter dialogues.
+# Transition: Stage1State -> Stage2State.
+
+const Stage2State = preload('res://Scripts/Gameplay/States/Stage2State.gd')
+const CRITTERS : Array[PackedScene] = [
+	preload('res://Scenes/Critters/CritterJesterka.tscn'),
+	preload('res://Scenes/Critters/CritterBrouk.tscn'),
+	preload('res://Scenes/Critters/CritterList.tscn'),
+	preload('res://Scenes/Critters/CritterSklenenka.tscn'),
+	preload('res://Scenes/Critters/CritterSnek.tscn'),
+	preload('res://Scenes/Critters/CritterKliste.tscn')
+]
+
+var snaps_done : int = 0
+var photos_total : int = 0
+var critters_done : int = 0
+var _queue : Array[PackedScene] = []
+var _current_critter : Node = null
+
+func enter(controller: Node) -> void:
+	controller.gameplay.visible = true
+	CircleBank.reset_all(); CircleBank.show_bank()
+	snaps_done = 0; critters_done = 0; photos_total = 0
+	for ph in controller.get_tree().get_nodes_in_group('photos'):
+		photos_total += 1
+		ph.snapped.connect(_on_photo_snapped)
+	_queue = CRITTERS.duplicate(); _queue.shuffle()
+	_spawn_next_critter(controller)
+
+func _on_photo_snapped(_p, _slot) -> void:
+	snaps_done += 1
+	_check_done()
+
+func _spawn_next_critter(controller: Node) -> void:
+	if _current_critter:
+		_current_critter.queue_free()
+	if _queue.is_empty():
+		_current_critter = null
+		_check_done()
+		return
+	_current_critter = _queue.pop_back().instantiate()
+	controller.get_tree().current_scene.add_child(_current_critter)
+	_current_critter.dialogue_done.connect(func():
+		critters_done += 1
+		_spawn_next_critter(controller)
+		_check_done()
+	)
+
+func _check_done() -> void:
+	if snaps_done == photos_total and critters_done == 6 and _current_critter == null:
+		transition_to.emit(Stage2State.new())

--- a/Scripts/Gameplay/States/Stage2State.gd
+++ b/Scripts/Gameplay/States/Stage2State.gd
@@ -1,0 +1,22 @@
+# scripts/Gameplay/States/Stage2State.gd
+extends StageState
+
+# Shows mid-stage panel then spawns woman.
+# Transition: Stage2State -> Stage3State.
+
+const Stage3State = preload('res://Scripts/Gameplay/States/Stage3State.gd')
+
+func enter(controller: Node) -> void:
+	controller.clear_overlay()
+	var mid := controller.mid_stage_panel.instantiate()
+	controller.overlay.add_child(mid)
+	mid.intro_finished.connect(func():
+		controller.clear_overlay()
+		var stack := controller.fetch_node(controller.stack_path, 'PhotoStack')
+		controller.woman = controller.WOMAN_SCENE.instantiate()
+		stack.add_child(controller.woman)
+		controller.woman.global_position = (controller._woman_spawn.global_position if controller._woman_spawn else Vector2(150,150))
+		controller.woman.all_words_transformed.connect(func():
+			transition_to.emit(Stage3State.new())
+		)
+	)

--- a/Scripts/Gameplay/States/Stage2State.gd
+++ b/Scripts/Gameplay/States/Stage2State.gd
@@ -7,16 +7,21 @@ extends StageState
 const Stage3State = preload('res://Scripts/Gameplay/States/Stage3State.gd')
 
 func enter(controller: Node) -> void:
-	controller.clear_overlay()
-	var mid := controller.mid_stage_panel.instantiate()
-	controller.overlay.add_child(mid)
-	mid.intro_finished.connect(func():
-		controller.clear_overlay()
-		var stack := controller.fetch_node(controller.stack_path, 'PhotoStack')
-		controller.woman = controller.WOMAN_SCENE.instantiate()
-		stack.add_child(controller.woman)
-		controller.woman.global_position = (controller._woman_spawn.global_position if controller._woman_spawn else Vector2(150,150))
-		controller.woman.all_words_transformed.connect(func():
-			transition_to.emit(Stage3State.new())
-		)
-	)
+        controller.clear_overlay()
+        var mid := controller.mid_stage_panel.instantiate()
+        controller.overlay.add_child(mid)
+        mid.intro_finished.connect(func():
+                controller.clear_overlay()
+                var stack := controller.fetch_node(controller.stack_path, "PhotoStack")
+                controller.woman = controller.WOMAN_SCENE.instantiate()
+                stack.add_child(controller.woman)
+                var spawn_pos := (
+                        controller._woman_spawn.global_position
+                        if controller._woman_spawn
+                        else Vector2(150, 150)
+                )
+                controller.woman.global_position = spawn_pos
+                controller.woman.all_words_transformed.connect(func():
+                        transition_to.emit(Stage3State.new())
+                )
+        )

--- a/Scripts/Gameplay/States/Stage3State.gd
+++ b/Scripts/Gameplay/States/Stage3State.gd
@@ -1,0 +1,21 @@
+# scripts/Gameplay/States/Stage3State.gd
+extends StageState
+
+# Shrinks woman and spawns fetus with dialogue.
+# Transition: Stage3State -> Stage4State.
+
+const Stage4State = preload('res://Scripts/Gameplay/States/Stage4State.gd')
+
+func enter(controller: Node) -> void:
+	var dest := controller._woman_target.global_position if controller._woman_target else Vector2(100,100)
+	controller.woman.create_tween().tween_property(controller.woman, 'global_position', dest, 0.8).set_trans(Tween.TRANS_SINE)
+	controller.woman.create_tween().tween_property(controller.woman, 'scale', Vector2.ONE * 0.3, 0.8)
+	await controller.get_tree().create_timer(0.8).timeout
+	controller.fetus = controller.FETUS_SCENE.instantiate()
+	controller.get_tree().current_scene.add_child(controller.fetus)
+	controller.fetus.global_position = (controller._fetus_spawn.global_position if controller._fetus_spawn else Vector2.ZERO)
+	controller.fetus.center_pos = controller._fetus_centre.global_position
+	AudioManager.play_sfx(controller.heartbeat_sfx)
+	controller.fetus.dialog_done.connect(func():
+		transition_to.emit(Stage4State.new())
+	)

--- a/Scripts/Gameplay/States/Stage3State.gd
+++ b/Scripts/Gameplay/States/Stage3State.gd
@@ -7,15 +7,35 @@ extends StageState
 const Stage4State = preload('res://Scripts/Gameplay/States/Stage4State.gd')
 
 func enter(controller: Node) -> void:
-	var dest := controller._woman_target.global_position if controller._woman_target else Vector2(100,100)
-	controller.woman.create_tween().tween_property(controller.woman, 'global_position', dest, 0.8).set_trans(Tween.TRANS_SINE)
-	controller.woman.create_tween().tween_property(controller.woman, 'scale', Vector2.ONE * 0.3, 0.8)
-	await controller.get_tree().create_timer(0.8).timeout
-	controller.fetus = controller.FETUS_SCENE.instantiate()
-	controller.get_tree().current_scene.add_child(controller.fetus)
-	controller.fetus.global_position = (controller._fetus_spawn.global_position if controller._fetus_spawn else Vector2.ZERO)
-	controller.fetus.center_pos = controller._fetus_centre.global_position
-	AudioManager.play_sfx(controller.heartbeat_sfx)
-	controller.fetus.dialog_done.connect(func():
-		transition_to.emit(Stage4State.new())
-	)
+        var dest := (
+                controller._woman_target.global_position
+                if controller._woman_target
+                else Vector2(100, 100)
+        )
+        var pos_tween := controller.woman.create_tween()
+        pos_tween.tween_property(
+                controller.woman,
+                "global_position",
+                dest,
+                0.8,
+        ).set_trans(Tween.TRANS_SINE)
+        controller.woman.create_tween().tween_property(
+                controller.woman,
+                "scale",
+                Vector2.ONE * 0.3,
+                0.8,
+        )
+        await controller.get_tree().create_timer(0.8).timeout
+        controller.fetus = controller.FETUS_SCENE.instantiate()
+        controller.get_tree().current_scene.add_child(controller.fetus)
+        var fetus_pos := (
+                controller._fetus_spawn.global_position
+                if controller._fetus_spawn
+                else Vector2.ZERO
+        )
+        controller.fetus.global_position = fetus_pos
+        controller.fetus.center_pos = controller._fetus_centre.global_position
+        AudioManager.play_sfx(controller.heartbeat_sfx)
+        controller.fetus.dialog_done.connect(func():
+                transition_to.emit(Stage4State.new())
+        )

--- a/Scripts/Gameplay/States/Stage4State.gd
+++ b/Scripts/Gameplay/States/Stage4State.gd
@@ -11,9 +11,14 @@ func enter(controller: Node) -> void:
 	for ph in controller.get_tree().get_nodes_in_group('photos'):
 		if ph.has_method('unlock_for_cleanup'):
 			ph.unlock_for_cleanup()
-	var river := controller.RIVER_SCENE.instantiate()
-	controller.get_tree().current_scene.add_child(river)
-	river.global_position = (controller._river_pos.global_position if controller._river_pos else Vector2(640,720))
-	river.cleanup_complete.connect(func():
-		transition_to.emit(EndState.new())
-	)
+        var river := controller.RIVER_SCENE.instantiate()
+        controller.get_tree().current_scene.add_child(river)
+        var river_pos := (
+                controller._river_pos.global_position
+                if controller._river_pos
+                else Vector2(640, 720)
+        )
+        river.global_position = river_pos
+        river.cleanup_complete.connect(func():
+                transition_to.emit(EndState.new())
+        )

--- a/Scripts/Gameplay/States/Stage4State.gd
+++ b/Scripts/Gameplay/States/Stage4State.gd
@@ -1,0 +1,19 @@
+# scripts/Gameplay/States/Stage4State.gd
+extends StageState
+
+# Handles cleanup of photos into the river.
+# Transition: Stage4State -> EndState.
+
+const EndState = preload('res://Scripts/Gameplay/States/EndState.gd')
+
+func enter(controller: Node) -> void:
+	CircleBank.hide_bank()
+	for ph in controller.get_tree().get_nodes_in_group('photos'):
+		if ph.has_method('unlock_for_cleanup'):
+			ph.unlock_for_cleanup()
+	var river := controller.RIVER_SCENE.instantiate()
+	controller.get_tree().current_scene.add_child(river)
+	river.global_position = (controller._river_pos.global_position if controller._river_pos else Vector2(640,720))
+	river.cleanup_complete.connect(func():
+		transition_to.emit(EndState.new())
+	)

--- a/Scripts/Gameplay/States/StageState.gd
+++ b/Scripts/Gameplay/States/StageState.gd
@@ -1,6 +1,6 @@
 # scripts/Gameplay/States/StageState.gd
-extends Node
 class_name StageState
+extends Node
 
 signal transition_to(next_state)
 

--- a/Scripts/Gameplay/States/StageState.gd
+++ b/Scripts/Gameplay/States/StageState.gd
@@ -1,0 +1,8 @@
+# scripts/Gameplay/States/StageState.gd
+extends Node
+class_name StageState
+
+signal transition_to(next_state)
+
+func enter(_controller: Node) -> void:
+	pass


### PR DESCRIPTION
## Summary
- introduce discrete Intro, Stage1–Stage4, and End state scripts
- refactor `StageController` to manage states and transitions
- document stage transitions and encapsulate critter queue and dialogues

## Testing
- `gdlint Scripts/Gameplay/StageController.gd Scripts/Gameplay/States/*.gd` *(fails: Definition out of order, max line length)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb4178688327820fc02ec5e045f2