### PR TITLE
Gate debug logs on debug builds

### DIFF
--- a/Scripts/Gameplay/Critter.gd
+++ b/Scripts/Gameplay/Critter.gd
@@ -16,7 +16,6 @@ var _view : Rect2
 var _dir  : Vector2 = Vector2.ZERO
 var _action_name : String
 var _triggered   : bool = false
-const DEBUG := true
 
 # ───────── READY ─────────
 func _ready() -> void:
@@ -109,7 +108,7 @@ func _trigger() -> void:
 	sprite.animation_finished.connect(_on_trigger_anim_finished, CONNECT_ONE_SHOT)
 
 	if one_liner_id == "":
-		if DEBUG: print("[Critter] (no one_liner_id) – only play trigger anim")
+		if OS.is_debug_build(): print("[Critter] (no one_liner_id) – only play trigger anim")
 		return
 
 	var dm : Node = get_tree().get_root().get_node_or_null("DialogueManager")
@@ -121,7 +120,7 @@ func _trigger() -> void:
 		return
 
 	# Connect to know when dialogue ends (one-shot).
-	if DEBUG: print("[Critter] → starting one-liner id='", one_liner_id, "'")
+	if OS.is_debug_build(): print("[Critter] → starting one-liner id='", one_liner_id, "'")
 	dm.connect("dialogue_finished", Callable(self, "_on_dialogue_finished"), CONNECT_ONE_SHOT)
 	dm.call("start", one_liner_id)
 
@@ -135,7 +134,7 @@ func _on_dialogue_finished(last_id: String) -> void:
 	# Ignore unrelated dialogues if multiple critters/photos can trigger
 	if last_id != one_liner_id:
 		return
-	if DEBUG: print("[Critter] dialogue finished id='", last_id, "'")
+	if OS.is_debug_build(): print("[Critter] dialogue finished id='", last_id, "'")
 	_triggered = false
 	sprite.play("move")
 	emit_signal("dialogue_done")

--- a/Scripts/Gameplay/Photo.gd
+++ b/Scripts/Gameplay/Photo.gd
@@ -32,7 +32,6 @@ var is_sealed : bool    = false
 static var current_drag    : Photo = null                # exclusive-drag lock
 static var _unused_tapes   : Array[Texture2D] = []       # shared between all photos
 
-const DEBUG := true
 
 # tape pool  (add the exact filenames you have in Assets/Tape/)
 const TAPE_TEXTURES : Array[Texture2D] = [
@@ -115,23 +114,23 @@ func _sprite_contains_screen_point(ph: Photo, screen_pt: Vector2) -> bool:
 func _try_snap() -> void:
 	var slot : Area2D = _nearest_slot()
 	if slot == null:
-		if DEBUG: print("[Photo] ⨯ no nearby slot – pos=", global_position)
+		if OS.is_debug_build(): print("[Photo] ⨯ no nearby slot – pos=", global_position)
 		return
 	if slot.slot_idx not in allowed_slots:
-		if DEBUG: print("[Photo] ⨯ slot not allowed idx=", slot.slot_idx, " allowed=", allowed_slots)
+		if OS.is_debug_build(): print("[Photo] ⨯ slot not allowed idx=", slot.slot_idx, " allowed=", allowed_slots)
 		return
 
 	var mem_id : String = MemoryPool.table.slot_to_memory_id[slot.slot_idx]
 	if not MemoryPool.is_free(mem_id):
-		if DEBUG: print("[Photo] ⨯ memory already used id=", mem_id)
+		if OS.is_debug_build(): print("[Photo] ⨯ memory already used id=", mem_id)
 		return
 
 	var dist : float = global_position.distance_to(slot.global_position)
 	if dist > snap_radius:
-		if DEBUG: print("[Photo] ⨯ too far dist=", dist, " radius=", snap_radius)
+		if OS.is_debug_build(): print("[Photo] ⨯ too far dist=", dist, " radius=", snap_radius)
 		return
 
-	if DEBUG: print("[Photo] ✓ snap OK slot=", slot.slot_idx, " mem=", mem_id)
+	if OS.is_debug_build(): print("[Photo] ✓ snap OK slot=", slot.slot_idx, " mem=", mem_id)
 	_snap_to_slot(slot, mem_id)
 
 func _snap_to_slot(slot: Area2D, mem_id: String) -> void:
@@ -151,10 +150,10 @@ func _snap_to_slot(slot: Area2D, mem_id: String) -> void:
 # ───────────────────────────
 func _start_dialogue_if_possible() -> void:
 	if dialog_id == "":
-		if DEBUG: print("[Photo] (no dialog_id set) – skip")
+		if OS.is_debug_build(): print("[Photo] (no dialog_id set) – skip")
 		return
 	if Engine.is_editor_hint():
-		if DEBUG: print("[Photo] editor hint – skip dialogue")
+		if OS.is_debug_build(): print("[Photo] editor hint – skip dialogue")
 		return
 
 	var dm : Node = get_tree().get_root().get_node_or_null("DialogueManager")
@@ -165,7 +164,7 @@ func _start_dialogue_if_possible() -> void:
 		push_warning("[Photo] DialogueManager is missing method 'start(String)'")
 		return
 
-	if DEBUG: print("[Photo] → starting dialogue id='", dialog_id, "'")
+	if OS.is_debug_build(): print("[Photo] → starting dialogue id='", dialog_id, "'")
 	dm.call("start", dialog_id)
 
 # ───────────────────────────


### PR DESCRIPTION
## Summary
- replace DEBUG constants with `OS.is_debug_build()` checks
- ensure debug `print` calls only run in debug builds

## Testing
- `godot3 --headless --check-only 2>&1 | head -n 20` *(fails: project requires newer Godot engine)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb2ffdd48327ad1561d2bc49bd2d