### PR TITLE
Refactor UI panel line storage

### DIFF
--- a/Scripts/UI/IntroPanel.gd
+++ b/Scripts/UI/IntroPanel.gd
@@ -1,7 +1,7 @@
 # scripts/UI/IntroPanel.gd
 extends "res://Scripts/UI/TextSequencePanel.gd"
 
-var lines : Array[String] = [
+const LINES : Array[String] = [
         "She was a tough child.",
         "Now she always seems to be on the verge of ABYSS.",
         "(Or something equally dramatic to emphasize her mental instability)",
@@ -11,3 +11,6 @@ var lines : Array[String] = [
         "The abyss has always had your voice.",
         "Hey."
 ]
+
+func _init() -> void:
+        lines = LINES

--- a/Scripts/UI/MidStagePanel.gd
+++ b/Scripts/UI/MidStagePanel.gd
@@ -1,5 +1,8 @@
 extends "res://Scripts/UI/TextSequencePanel.gd"
 
-var lines : Array[String] = [
+const LINES : Array[String] = [
         "Now She is ready to hear your part of the story."
 ]
+
+func _init() -> void:
+        lines = LINES

--- a/Scripts/UI/ParentIntroPanel.gd
+++ b/Scripts/UI/ParentIntroPanel.gd
@@ -1,7 +1,7 @@
 extends "res://Scripts/UI/TextSequencePanel.gd"
 
 # Specific lines for the “parent” branch
-var lines : Array[String] = [
+const LINES : Array[String] = [
         "I had a happy childhood.\n...\nI had a childhood.",
         "You gave me some fundamental life skills.",
         "Stealth\nWoodcraft\nSelf-sufficiency\nResponsibility for the emotions of others",
@@ -10,3 +10,6 @@ var lines : Array[String] = [
         "But, all irony aside...",
         "...I know you did your best.\n Thank you.",
 ]
+
+func _init() -> void:
+        lines = LINES


### PR DESCRIPTION
## Summary
- store panel text in `LINES` constants instead of redefining `lines`
- set `lines` from the constants during initialization to avoid member conflicts

## Testing
- `/tmp/godot-bin/Godot_v4.2.2-stable_linux.x86_64 --headless --path . --check-only --script Scripts/UI/IntroPanel.gd`
- `/tmp/godot-bin/Godot_v4.2.2-stable_linux.x86_64 --headless --path . --check-only --script Scripts/UI/MidStagePanel.gd`
- `/tmp/godot-bin/Godot_v4.2.2-stable_linux.x86_64 --headless --path . --check-only --script Scripts/UI/ParentIntroPanel.gd`


------
https://chatgpt.com/codex/tasks/task_e_6898f220a4488327951c45723843ac64