### PR TITLE
Ensure Stage 1 waits for photo dialogues

### DIFF
--- a/Scripts/Gameplay/Photo.gd
+++ b/Scripts/Gameplay/Photo.gd
@@ -8,6 +8,7 @@ extends Area2D
 signal snapped(photo: Photo, slot: Area2D)
 signal drag_started(photo)
 signal drag_ended(photo)
+signal dialogue_done(photo)
 
 # ───────────────────────────
 #  Inspector fields
@@ -131,23 +132,31 @@ func _snap_to_slot(slot: Area2D, mem_id: String) -> void:
 	set_pickable(false)
 
 	MemoryPool.claim(mem_id)
-	_attach_random_tape()
-	emit_signal("snapped", self, slot)
-	AudioManager.play_sfx("photoSnap")
+        _attach_random_tape()
+        emit_signal("snapped", self, slot)
+        AudioManager.play_sfx("photoSnap")
 
-	_start_dialogue_if_possible()
+        _start_dialogue_if_possible()
 
 # ───────────────────────────
 #  Dialogue trigger (+ debug)
 # ───────────────────────────
 func _start_dialogue_if_possible() -> void:
-	if dialog_id == "":
-		return
-	if Engine.is_editor_hint():
-		return
-	if not DialogueManager.has_method("start"):
-			return
-	DialogueManager.start(dialog_id)
+        if dialog_id == "":
+                return
+        if Engine.is_editor_hint():
+                return
+        if not DialogueManager.has_method("start"):
+                        return
+        DialogueManager.dialogue_finished.connect(_on_dialogue_finished)
+        DialogueManager.start(dialog_id)
+
+func _on_dialogue_finished(last_id: String) -> void:
+        if last_id != dialog_id:
+                return
+        if DialogueManager.dialogue_finished.is_connected(_on_dialogue_finished):
+                DialogueManager.dialogue_finished.disconnect(_on_dialogue_finished)
+        emit_signal("dialogue_done", self)
 # ───────────────────────────
 #  Helpers
 # ───────────────────────────

--- a/Scripts/Gameplay/StageController.gd
+++ b/Scripts/Gameplay/StageController.gd
@@ -3,7 +3,7 @@ extends Node
 #
 # Flow summary
 #   • parent / difficulty   (unchanged)
-#   • Stage 1  – 6 photos snapped AND 6 critter dialogues done
+#   • Stage 1  – all photo dialogues and critter dialogues finished
 #   • Stage 2  – mid panel → woman photo
 #   • Stage 3  – woman shrinks to marker, fetus spawns at FetusSpawn
 #               click fetus → centre + heartbeat + dialogue
@@ -44,7 +44,7 @@ var overlay  : CanvasLayer = null
 var woman    : Node = null
 var fetus    : Node = null
 
-var snaps_done     : int = 0
+var photo_dialogues_done : int = 0
 var photos_total   : int = 0
 var critters_done  : int = 0
 
@@ -81,9 +81,9 @@ func _ready() -> void:
 	overlay.add_child(parent)
 	parent.parent_chosen.connect(_on_parent_decided)
 
-	for ph in get_tree().get_nodes_in_group("photos"):
-		photos_total += 1
-		ph.snapped.connect(_on_photo_snapped)
+        for ph in get_tree().get_nodes_in_group("photos"):
+                photos_total += 1
+                ph.dialogue_done.connect(_on_photo_dialogue_done)
 
 # ──────── PARENT / DIFFICULTY ────────
 func _on_parent_decided(is_parent:bool) -> void:
@@ -121,12 +121,12 @@ func _apply_slot_cfg(path:String) -> void:
 
 # ──────── STAGE 1 ────────
 func _enter_stage1() -> void:
-	stage = Stage.STAGE1
-	gameplay.visible = true
-	CircleBank.reset_all(); CircleBank.show_bank()
-	snaps_done = 0; critters_done = 0
-	_queue = CRITTERS.duplicate(); _queue.shuffle()
-	_spawn_next_critter()
+        stage = Stage.STAGE1
+        gameplay.visible = true
+        CircleBank.reset_all(); CircleBank.show_bank()
+        photo_dialogues_done = 0; critters_done = 0
+        _queue = CRITTERS.duplicate(); _queue.shuffle()
+        _spawn_next_critter()
 
 func _spawn_next_critter() -> void:
 	if _current_critter: _current_critter.queue_free()
@@ -143,14 +143,14 @@ func _on_critter_done() -> void:
 	_spawn_next_critter()        # continue queue
 	_check_stage1_done()
 
-func _on_photo_snapped(_p, _slot) -> void:
-	if stage != Stage.STAGE1: return
-	snaps_done += 1
-	_check_stage1_done()
+func _on_photo_dialogue_done(_p) -> void:
+        if stage != Stage.STAGE1: return
+        photo_dialogues_done += 1
+        _check_stage1_done()
 
 func _check_stage1_done() -> void:
-	if snaps_done == photos_total and critters_done == CRITTERS.size() and _current_critter == null:
-		_enter_stage2()
+        if photo_dialogues_done == photos_total and critters_done == CRITTERS.size() and _current_critter == null:
+                _enter_stage2()
 
 # ──────── STAGE 2 (mid panel → woman) ────────
 func _enter_stage2() -> void:


### PR DESCRIPTION
## Summary
- Emit a `dialogue_done` signal from each Photo once its dialogue concludes
- Track completed photo dialogues in StageController and advance to Stage 2 only when all dialogues, including critters, are finished

## Testing
- `gdlint Scripts/Gameplay/Photo.gd Scripts/Gameplay/StageController.gd` *(fails: command not found)*
- `python -m gdtoolkit.lint Scripts/Gameplay/Photo.gd Scripts/Gameplay/StageController.gd` *(module not found)*
- `godot --headless --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68992b0a4e90832793f868409c45bd0b