### PR TITLE
Emit dialogue_done when dialogue unavailable

### DIFF
--- a/Scripts/Gameplay/Photo.gd
+++ b/Scripts/Gameplay/Photo.gd
@@ -27,6 +27,7 @@ var _dragging : bool    = false
 var _drag_off : Vector2
 var _snapped  : bool    = false
 var _in_hand  : bool    = false
+var _dialogue_complete : bool = false
 
 static var current_drag    : Photo = null                # exclusive-drag lock
 static var _unused_tapes   : Array[Texture2D] = []       # shared between all photos
@@ -140,21 +141,30 @@ func _snap_to_slot(slot: Area2D, mem_id: String) -> void:
 #  Dialogue trigger
 # ───────────────────────────
 func _start_dialogue_if_possible() -> void:
-	if dialog_id == "":
-			return
-	if Engine.is_editor_hint():
-			return
-	if not DialogueManager.has_method("start"):
-					return
-	DialogueManager.dialogue_finished.connect(_on_dialogue_finished)
-	DialogueManager.start(dialog_id)
+        if _dialogue_complete:
+                return
+        if dialog_id == "":
+                _dialogue_complete = true
+                emit_signal("dialogue_done", self)
+                return
+        if Engine.is_editor_hint():
+                return
+        if not DialogueManager.has_method("start"):
+                _dialogue_complete = true
+                emit_signal("dialogue_done", self)
+                return
+        DialogueManager.dialogue_finished.connect(_on_dialogue_finished)
+        DialogueManager.start(dialog_id)
 
 func _on_dialogue_finished(last_id: String) -> void:
-		if last_id != dialog_id:
-				return
-		if DialogueManager.dialogue_finished.is_connected(_on_dialogue_finished):
-				DialogueManager.dialogue_finished.disconnect(_on_dialogue_finished)
-		emit_signal("dialogue_done", self)
+                if last_id != dialog_id:
+                                return
+                if DialogueManager.dialogue_finished.is_connected(_on_dialogue_finished):
+                                DialogueManager.dialogue_finished.disconnect(_on_dialogue_finished)
+                if _dialogue_complete:
+                        return
+                _dialogue_complete = true
+                emit_signal("dialogue_done", self)
 # ───────────────────────────
 #  Helpers
 # ───────────────────────────


### PR DESCRIPTION
## Summary
- Mark photos as having completed dialogue once handled
- Emit `dialogue_done` immediately when dialog is missing or DialogueManager can't run
- Guard against duplicate `dialogue_done` emissions

## Testing
- `gdlint Scripts/Gameplay/Photo.gd` *(fails: Definition out of order in global scope)*
- `curl -L -o godot.zip https://downloads.tuxfamily.org/godotengine/4.2.2/Godot_v4.2.2-stable_linux.x86_64.zip` *(connection timeout: unable to download Godot for runtime test)*

------
https://chatgpt.com/codex/tasks/task_e_6899314a023c8327a7ad621a7953376a