### PR TITLE
refactor: standardize dialogue body key

### DIFF
--- a/Data/Dialogue/outro.json
+++ b/Data/Dialogue/outro.json
@@ -1,7 +1,6 @@
 {
   "id": "outro",
-  "text": "This is the closest to freedom I will ever be.\n\n 
-I just have to get used to how empty it feels.",
+  "body": "This is the closest to freedom I will ever be.\n\nI just have to get used to how empty it feels.",
   "choices": [
 	{"label": "Continue", "next": "cleanup_start"}
   ]


### PR DESCRIPTION
## Summary
- replace `text` with `body` in the outro dialogue JSON to match other dialogue files
- ensure dialogue data parses correctly with escaped newlines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899305f8a888327aa131ec6f28c5e6f