### PR TITLE
feat: add base overlay panel

### DIFF
--- a/Scenes/Overlays/BasePanel.tscn
+++ b/Scenes/Overlays/BasePanel.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=2 format=3 uid="uid://cqiyk0hntms4q"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_base"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="BasePanel" type="Panel"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_base")
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="LineLabel" type="Label" parent="CenterContainer/VBoxContainer"]
+custom_minimum_size = Vector2(300, 300)
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 28
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2

--- a/Scenes/Overlays/DifficultyChoicePanel.tscn
+++ b/Scenes/Overlays/DifficultyChoicePanel.tscn
@@ -1,48 +1,25 @@
-[gd_scene load_steps=4 format=3 uid="uid://drrbg65xm6npm"]
+[gd_scene load_steps=3 format=3 uid="uid://drrbg65xm6npm"]
 
-[ext_resource type="Script" uid="uid://21176bfc7lka" path="res://Scripts/UI/DifficultyChoicePanel.gd" id="1_2l3io"]
+[ext_resource type="PackedScene" uid="uid://cqiyk0hntms4q" path="res://Scenes/Overlays/BasePanel.tscn" id="1"]
+[ext_resource type="Script" uid="uid://21176bfc7lka" path="res://Scripts/UI/DifficultyChoicePanel.gd" id="2"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2l3io"]
-bg_color = Color(0, 0, 0, 1)
+[node name="DifficultyChoicePanel" instance=ExtResource("1")]
+script = ExtResource("2")
+easy_btn_path = NodePath("CenterContainer/VBoxContainer/HBoxContainer/EasyBtn")
+hard_btn_path = NodePath("CenterContainer/VBoxContainer/HBoxContainer/HardBtn")
 
-[sub_resource type="LabelSettings" id="LabelSettings_2l3io"]
-font_size = 23
+[node name="LineLabel" parent="CenterContainer/VBoxContainer"]
+text = "How hard is it for you to forgive?\n\nPlease select your difficulty:"
+autowrap_mode = 3
 
-[node name="DifficultyChoicePanel" type="Panel"]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_2l3io")
-script = ExtResource("1_2l3io")
-
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-layout_mode = 0
-offset_left = 899.0
-offset_top = 632.0
-offset_right = 993.0
-offset_bottom = 663.0
-
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="CenterContainer/VBoxContainer"]
 layout_mode = 2
+alignment = 1
 
-[node name="EasyBtn" type="Button" parent="VBoxContainer/HBoxContainer"]
+[node name="EasyBtn" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 text = "Easy"
 
-[node name="HardBtn" type="Button" parent="VBoxContainer/HBoxContainer"]
+[node name="HardBtn" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 text = "Hard"
-
-[node name="Label" type="Label" parent="."]
-layout_mode = 0
-offset_left = 767.0
-offset_top = 453.0
-offset_right = 1597.0
-offset_bottom = 612.0
-text = "How hard is it for you to forgive?
-
-Please select your difficulty:"
-label_settings = SubResource("LabelSettings_2l3io")
-autowrap_mode = 3

--- a/Scenes/Overlays/IntroPanel.tscn
+++ b/Scenes/Overlays/IntroPanel.tscn
@@ -1,32 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://dt1pw6kymrvga"]
+[gd_scene load_steps=2 format=3 uid="uid://dt1pw6kymrvga"]
 
-[ext_resource type="Script" uid="uid://dge8dfngidg28" path="res://Scripts/UI/IntroPanel.gd" id="1_g5a4p"]
+[ext_resource type="PackedScene" uid="uid://cqiyk0hntms4q" path="res://Scenes/Overlays/BasePanel.tscn" id="1"]
+[ext_resource type="Script" uid="uid://dge8dfngidg28" path="res://Scripts/UI/IntroPanel.gd" id="2"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y1pyq"]
-bg_color = Color(0, 0, 0, 1)
-
-[node name="IntroPanel" type="Panel"]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_y1pyq")
-script = ExtResource("1_g5a4p")
-
-[node name="CenterContainer" type="CenterContainer" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="LineLabel" type="Label" parent="CenterContainer"]
-custom_minimum_size = Vector2(300, 300)
-layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_font_sizes/font_size = 28
-horizontal_alignment = 1
-vertical_alignment = 1
-autowrap_mode = 2
+[node name="IntroPanel" instance=ExtResource("1")]
+script = ExtResource("2")

--- a/Scenes/Overlays/MidStagePanel.tscn
+++ b/Scenes/Overlays/MidStagePanel.tscn
@@ -1,32 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://bvc3anuilxmgo"]
+[gd_scene load_steps=2 format=3 uid="uid://bvc3anuilxmgo"]
 
-[ext_resource type="Script" uid="uid://bimbfgmve10en" path="res://Scripts/UI/MidStagePanel.gd" id="1_mak0h"]
+[ext_resource type="PackedScene" uid="uid://cqiyk0hntms4q" path="res://Scenes/Overlays/BasePanel.tscn" id="1"]
+[ext_resource type="Script" uid="uid://bimbfgmve10en" path="res://Scripts/UI/MidStagePanel.gd" id="2"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y1pyq"]
-bg_color = Color(0, 0, 0, 1)
-
-[node name="MidStagePanel" type="Panel"]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_y1pyq")
-script = ExtResource("1_mak0h")
-
-[node name="CenterContainer" type="CenterContainer" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="LineLabel" type="Label" parent="CenterContainer"]
-custom_minimum_size = Vector2(300, 300)
-layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_font_sizes/font_size = 28
-horizontal_alignment = 1
-vertical_alignment = 1
-autowrap_mode = 2
+[node name="MidStagePanel" instance=ExtResource("1")]
+script = ExtResource("2")

--- a/Scenes/Overlays/ParentChoicePanel.tscn
+++ b/Scenes/Overlays/ParentChoicePanel.tscn
@@ -1,45 +1,24 @@
-[gd_scene load_steps=4 format=3 uid="uid://dlfjmnwyap55e"]
+[gd_scene load_steps=3 format=3 uid="uid://dlfjmnwyap55e"]
 
-[ext_resource type="Script" uid="uid://6whkirprbgcn" path="res://Scripts/UI/ParentChoicePanel.gd" id="1_hmjht"]
+[ext_resource type="PackedScene" uid="uid://cqiyk0hntms4q" path="res://Scenes/Overlays/BasePanel.tscn" id="1"]
+[ext_resource type="Script" uid="uid://6whkirprbgcn" path="res://Scripts/UI/ParentChoicePanel.gd" id="2"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hmjht"]
-bg_color = Color(0, 0, 0, 1)
+[node name="ParentChoicePanel" instance=ExtResource("1")]
+script = ExtResource("2")
+yes_btn_path = NodePath("CenterContainer/VBoxContainer/HBoxContainer/YesBtn")
+no_btn_path = NodePath("CenterContainer/VBoxContainer/HBoxContainer/NoBtn")
 
-[sub_resource type="LabelSettings" id="LabelSettings_hmjht"]
-font_size = 25
+[node name="LineLabel" parent="CenterContainer/VBoxContainer"]
+text = "Are you her parent?"
 
-[node name="ParentChoicePanel" type="Panel"]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_hmjht")
-script = ExtResource("1_hmjht")
-
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-layout_mode = 0
-offset_left = 965.0
-offset_top = 482.0
-offset_right = 1035.0
-offset_bottom = 522.0
-
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="CenterContainer/VBoxContainer"]
 layout_mode = 2
+alignment = 1
 
-[node name="YesBtn" type="Button" parent="VBoxContainer/HBoxContainer"]
+[node name="YesBtn" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 text = "Yes"
 
-[node name="NoBtn" type="Button" parent="VBoxContainer/HBoxContainer"]
+[node name="NoBtn" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 text = "No"
-
-[node name="Label" type="Label" parent="."]
-layout_mode = 0
-offset_left = 884.0
-offset_top = 409.0
-offset_right = 1124.0
-offset_bottom = 444.0
-text = "Are you her parent?"
-label_settings = SubResource("LabelSettings_hmjht")

--- a/Scenes/Overlays/ParentIntroPanel.tscn
+++ b/Scenes/Overlays/ParentIntroPanel.tscn
@@ -1,32 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://b7xedi8tnuqpo"]
+[gd_scene load_steps=2 format=3 uid="uid://b7xedi8tnuqpo"]
 
-[ext_resource type="Script" uid="uid://ds33ebwjdh5wl" path="res://Scripts/UI/ParentIntroPanel.gd" id="1_bvvmn"]
+[ext_resource type="PackedScene" uid="uid://cqiyk0hntms4q" path="res://Scenes/Overlays/BasePanel.tscn" id="1"]
+[ext_resource type="Script" uid="uid://ds33ebwjdh5wl" path="res://Scripts/UI/ParentIntroPanel.gd" id="2"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y1pyq"]
-bg_color = Color(0, 0, 0, 1)
-
-[node name="IntroPanel" type="Panel"]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_y1pyq")
-script = ExtResource("1_bvvmn")
-
-[node name="CenterContainer" type="CenterContainer" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="LineLabel" type="Label" parent="CenterContainer"]
-custom_minimum_size = Vector2(300, 300)
-layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_font_sizes/font_size = 28
-horizontal_alignment = 1
-vertical_alignment = 1
-autowrap_mode = 2
+[node name="ParentIntroPanel" instance=ExtResource("1")]
+script = ExtResource("2")

--- a/Scripts/UI/DifficultyChoicePanel.gd
+++ b/Scripts/UI/DifficultyChoicePanel.gd
@@ -1,8 +1,11 @@
 extends Panel
 signal difficulty_chosen(is_easy:bool)
 
-@onready var easy := $"VBoxContainer/HBoxContainer/EasyBtn"
-@onready var hard := $"VBoxContainer/HBoxContainer/HardBtn"
+@export var easy_btn_path: NodePath
+@export var hard_btn_path: NodePath
+
+@onready var easy: Button = get_node(easy_btn_path)
+@onready var hard: Button = get_node(hard_btn_path)
 
 func _ready() -> void:
 	easy.pressed.connect(func(): difficulty_chosen.emit(true);  queue_free())

--- a/Scripts/UI/ParentChoicePanel.gd
+++ b/Scripts/UI/ParentChoicePanel.gd
@@ -1,8 +1,11 @@
 extends Panel
 signal parent_chosen(is_parent:bool)
 
-@onready var yes_btn := $"VBoxContainer/HBoxContainer/YesBtn"
-@onready var no_btn  := $"VBoxContainer/HBoxContainer/NoBtn"
+@export var yes_btn_path: NodePath
+@export var no_btn_path: NodePath
+
+@onready var yes_btn: Button = get_node(yes_btn_path)
+@onready var no_btn : Button = get_node(no_btn_path)
 
 func _ready() -> void:
 	yes_btn.pressed.connect(_on_yes)

--- a/Scripts/UI/TextSequencePanel.gd
+++ b/Scripts/UI/TextSequencePanel.gd
@@ -3,7 +3,8 @@ signal intro_finished
 
 var lines : Array[String] = []
 
-@onready var _label : Label = $CenterContainer/LineLabel
+@export var label_path: NodePath = "CenterContainer/VBoxContainer/LineLabel"
+@onready var _label : Label = get_node(label_path)
 var _idx : int = 0
 
 func _ready() -> void:


### PR DESCRIPTION
## Summary
- add BasePanel overlay with shared styling and layout
- rebuild all overlay panels to extend BasePanel
- expose button paths via exports for choice panels

## Testing
- `godot3 --headless --check-only project.godot` *(fails: project uses newer Godot config version)*

------
https://chatgpt.com/codex/tasks/task_e_68992ff718448327a775f348192492b9