### PR TITLE
Anchor dialogue choice box to bottom

### DIFF
--- a/Scenes/DialogueLayer.tscn
+++ b/Scenes/DialogueLayer.tscn
@@ -65,10 +65,20 @@ bbcode_enabled = true
 fit_content = true
 scroll_active = false
 
-[node name="ChoiceBox" type="VBoxContainer" parent="MarginContainer/DialogueUI/Backplate/Content/BodyAndChoices"]
+[node name="Choices" type="VBoxContainer" parent="MarginContainer/DialogueUI/Backplate/Content/BodyAndChoices"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Spacer" type="Control" parent="MarginContainer/DialogueUI/Backplate/Content/BodyAndChoices/Choices"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="ChoiceBox" type="VBoxContainer" parent="MarginContainer/DialogueUI/Backplate/Content/BodyAndChoices/Choices"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 0
+anchor_bottom = 1.0
 theme_override_constants/separation = 10
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="MarginContainer"]

--- a/Scripts/UI/DialogueUI.gd
+++ b/Scripts/UI/DialogueUI.gd
@@ -37,8 +37,8 @@ func _autowire_nodes() -> void:
 
 	if _body == null:
 		_body = get_node_or_null("Backplate/Content/BodyAndChoices/LineRow/BodyLabel") as RichTextLabel
-	if _choice_box == null:
-		_choice_box = get_node_or_null("Backplate/Content/BodyAndChoices/ChoiceBox") as VBoxContainer
+        if _choice_box == null:
+                _choice_box = get_node_or_null("Backplate/Content/BodyAndChoices/Choices/ChoiceBox") as VBoxContainer
 	if _portrait == null:
 		_portrait = get_node_or_null("Backplate/Content/BodyAndChoices/LineRow/Portrait") as TextureRect
 	if _anim == null:


### PR DESCRIPTION
## Summary
- Anchor choice box to the bottom of the dialogue UI using a wrapper container and spacer.
- Update dialogue script to reference the new choice box path.

## Testing
- `godot3 --headless --run-tests` *(fails: project uses a newer config version)*

------
https://chatgpt.com/codex/tasks/task_e_68992ff179488327870cfcfb48766792