### PR TITLE
Use autowrap mode for dialogue buttons

### DIFF
--- a/Scripts/UI/DialogueUI.gd
+++ b/Scripts/UI/DialogueUI.gd
@@ -131,14 +131,14 @@ func _clear_choices() -> void:
 		c.queue_free()
 
 func _add_choice_button(index: int, label_text: String) -> void:
-	var b: Button = Button.new()
-	b.text = label_text
-	b.focus_mode = Control.FOCUS_ALL
-	b.autowrap = true
-	b.size_flags_horizontal = Control.SIZE_FILL
-	b.size_flags_vertical = Control.SIZE_EXPAND
-	b.mouse_entered.connect(_on_btn_hovered)
-	b.pressed.connect(_on_btn_pressed.bind(index))
+        var b: Button = Button.new()
+        b.text = label_text
+        b.focus_mode = Control.FOCUS_ALL
+        b.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+        b.size_flags_horizontal = Control.SIZE_FILL
+        b.size_flags_vertical = Control.SIZE_EXPAND
+        b.mouse_entered.connect(_on_btn_hovered)
+        b.pressed.connect(_on_btn_pressed.bind(index))
 
 	var btn_theme_path_s: String = _current_button_theme_path()
 	if btn_theme_path_s != "":
@@ -153,14 +153,14 @@ func _add_choice_button(index: int, label_text: String) -> void:
 	_choice_box.add_child(b)
 
 func _add_continue_button() -> void:
-	var b: Button = Button.new()
-	b.text = "Continue"
-	b.focus_mode = Control.FOCUS_ALL
-	b.autowrap = true
-	b.size_flags_horizontal = Control.SIZE_FILL
-	b.size_flags_vertical = Control.SIZE_EXPAND
-	b.mouse_entered.connect(_on_btn_hovered)
-	b.pressed.connect(_on_continue_pressed)
+        var b: Button = Button.new()
+        b.text = "Continue"
+        b.focus_mode = Control.FOCUS_ALL
+        b.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+        b.size_flags_horizontal = Control.SIZE_FILL
+        b.size_flags_vertical = Control.SIZE_EXPAND
+        b.mouse_entered.connect(_on_btn_hovered)
+        b.pressed.connect(_on_continue_pressed)
 	b.add_theme_color_override("font_color", Color(1, 1, 1, 1))
 	b.add_theme_color_override("font_hover_color", Color(1, 1, 1, 1))
 	b.add_theme_color_override("font_pressed_color", Color(1, 1, 1, 1))


### PR DESCRIPTION
## Summary
- ensure dialogue choice and continue buttons wrap text via `TextServer.AUTOWRAP_WORD_SMART`

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*


------
https://chatgpt.com/codex/tasks/task_e_6899377b2044832785abc29c0ea794dc