### PR TITLE
Refactor overlay panels to use anchored layout

### DIFF
--- a/Scenes/Overlays/DifficultyChoicePanel.tscn
+++ b/Scenes/Overlays/DifficultyChoicePanel.tscn
@@ -17,32 +17,43 @@ grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_2l3io")
 script = ExtResource("1_2l3io")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-layout_mode = 0
-offset_left = 899.0
-offset_top = 632.0
-offset_right = 993.0
-offset_bottom = 663.0
+[node name="CenterContainer" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 
-[node name="EasyBtn" type="Button" parent="VBoxContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="CenterContainer/VBoxContainer"]
 layout_mode = 2
-text = "Easy"
-
-[node name="HardBtn" type="Button" parent="VBoxContainer/HBoxContainer"]
-layout_mode = 2
-text = "Hard"
-
-[node name="Label" type="Label" parent="."]
-layout_mode = 0
-offset_left = 767.0
-offset_top = 453.0
-offset_right = 1597.0
-offset_bottom = 612.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
 text = "How hard is it for you to forgive?
 
 Please select your difficulty:"
 label_settings = SubResource("LabelSettings_2l3io")
 autowrap_mode = 3
+
+[node name="HBoxContainer" type="HBoxContainer" parent="CenterContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="EasyBtn" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Easy"
+
+[node name="HardBtn" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Hard"
+

--- a/Scenes/Overlays/ParentChoicePanel.tscn
+++ b/Scenes/Overlays/ParentChoicePanel.tscn
@@ -17,29 +17,40 @@ grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_hmjht")
 script = ExtResource("1_hmjht")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-layout_mode = 0
-offset_left = 965.0
-offset_top = 482.0
-offset_right = 1035.0
-offset_bottom = 522.0
+[node name="CenterContainer" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 
-[node name="YesBtn" type="Button" parent="VBoxContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="CenterContainer/VBoxContainer"]
 layout_mode = 2
-text = "Yes"
-
-[node name="NoBtn" type="Button" parent="VBoxContainer/HBoxContainer"]
-layout_mode = 2
-text = "No"
-
-[node name="Label" type="Label" parent="."]
-layout_mode = 0
-offset_left = 884.0
-offset_top = 409.0
-offset_right = 1124.0
-offset_bottom = 444.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
 text = "Are you her parent?"
 label_settings = SubResource("LabelSettings_hmjht")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="CenterContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="YesBtn" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Yes"
+
+[node name="NoBtn" type="Button" parent="CenterContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "No"
+


### PR DESCRIPTION
## Summary
- Replace fixed offsets in DifficultyChoicePanel and ParentChoicePanel with anchored CenterContainer/VBox setups for scalable UI
- Apply size flags to controls for responsive alignment

## Testing
- `apt-get install -y godot4` *(failed: Unable to locate package godot4)*
- `godot3-server --path . --quit` *(failed: config version 5 is incompatible with Godot 3)*

------
https://chatgpt.com/codex/tasks/task_e_68992ff069508327b9100b6f5099ea4f