### PR TITLE
Add reset-based restart flow

### DIFF
--- a/Scripts/Gameplay/StageController.gd
+++ b/Scripts/Gameplay/StageController.gd
@@ -198,13 +198,40 @@ func _enter_stage4() -> void:
 
 # ──────── OUTRO ────────
 func _enter_end() -> void:
-	stage = Stage.END
-	DialogueManager.start("outro")
+        stage = Stage.END
+        DialogueManager.start("outro")
+
+# ──────── RESET ────────
+func reset() -> void:
+        stage = Stage.INTRO
+        photo_dialogues_done = 0
+        photos_total = 0
+        critters_done = 0
+
+        _queue.clear()
+        if _current_critter:
+                _current_critter.queue_free()
+                _current_critter = null
+
+        if woman:
+                woman.queue_free()
+                woman = null
+        if fetus:
+                fetus.queue_free()
+                fetus = null
+
+        gameplay = null
+        overlay = null
+
+        MemoryPool.init_from_table(memory_table)
+        CircleBank.reset_all()
+
+        get_tree().change_scene_to_file("res://Scenes/Main.tscn")
 
 # ──────── helpers ────────
 func _clear_overlay() -> void:
-	if overlay == null: return
-	for c in overlay.get_children(): c.queue_free()
+        if overlay == null: return
+        for c in overlay.get_children(): c.queue_free()
 
 func _fetch_node(path:NodePath, fallback:String) -> Node:
 	if path != NodePath(""):

--- a/Scripts/UI/ButtonBar.gd
+++ b/Scripts/UI/ButtonBar.gd
@@ -2,5 +2,7 @@ extends HBoxContainer
 @onready var restart_btn := $RestartBtn
 @onready var quit_btn    := $QuitBtn
 func _ready():
-	restart_btn.pressed.connect(get_tree().reload_current_scene)
-	quit_btn.pressed.connect(get_tree().quit)
+        var sc := get_tree().current_scene.get_node_or_null("StageController")
+        if sc:
+                restart_btn.pressed.connect(sc.reset)
+        quit_btn.pressed.connect(get_tree().quit)


### PR DESCRIPTION
## Summary
- connect restart button to StageController.reset
- add reset logic that clears game state and reloads main scene

## Testing
- `godot3-server --check-only Scenes/Main.tscn` *(fails: Can't open project at '/workspace/PLSHLP/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine. Expected config version: 4)*

------
https://chatgpt.com/codex/tasks/task_e_68993901e934832780ad43e1b835c5c3