### PR TITLE
Allow multiple critters and stage 4 cleanup

### DIFF
--- a/Scripts/Gameplay/Critter.gd
+++ b/Scripts/Gameplay/Critter.gd
@@ -18,12 +18,17 @@ var _triggered   : bool = false
 
 # ───────── READY ─────────
 func _ready() -> void:
-	vp.size_changed.connect(_on_viewport_resized)
-	_refresh_view_rect()
+        add_to_group("critters")
+        add_to_group("discardable")
+        z_index = 10000
+        z_as_relative = false
 
-	_assign_unique_key()
-	_spawn_at_random_edge()
-	sprite.play("move")
+        vp.size_changed.connect(_on_viewport_resized)
+        _refresh_view_rect()
+
+        _assign_unique_key()
+        _spawn_at_random_edge()
+        sprite.play("move")
 
 # ───────── VIEW UTIL ─────────
 func _refresh_view_rect() -> void:
@@ -121,5 +126,9 @@ func _on_dialogue_finished(last_id: String) -> void:
 	if last_id != one_liner_id:
 		return
 	_triggered = false
-	sprite.play("move")
-	emit_signal("dialogue_done")
+        sprite.play("move")
+        emit_signal("dialogue_done")
+
+# ───────── CLEANUP ─────────
+func unlock_for_cleanup() -> void:
+        queue_free()

--- a/Scripts/Gameplay/StageController.gd
+++ b/Scripts/Gameplay/StageController.gd
@@ -58,7 +58,6 @@ const CRITTERS : Array[PackedScene] = [
 	preload("res://Scenes/Critters/CritterKliste.tscn")
 ]
 var _queue : Array[PackedScene] = []
-var _current_critter : Node = null
 
 # ───────── PRELOADS ─────────
 # Gameplay depends on a few key scenes. These preloads make their
@@ -125,18 +124,16 @@ func _enter_stage1() -> void:
 		gameplay.visible = true
 		CircleBank.reset_all(); CircleBank.show_bank()
 		photo_dialogues_done = 0; critters_done = 0
-		_queue = CRITTERS.duplicate(); _queue.shuffle()
-		_spawn_next_critter()
+                _queue = CRITTERS.duplicate(); _queue.shuffle()
+                _spawn_next_critter()
 
 func _spawn_next_critter() -> void:
-	if _current_critter: _current_critter.queue_free()
-	if _queue.is_empty():
-		_current_critter = null
-		_check_stage1_done()
-		return
-	_current_critter = _queue.pop_back().instantiate()
-	get_tree().current_scene.add_child(_current_critter)
-	_current_critter.dialogue_done.connect(_on_critter_done, CONNECT_ONE_SHOT)
+        if _queue.is_empty():
+                _check_stage1_done()
+                return
+        var cr := _queue.pop_back().instantiate()
+        get_tree().current_scene.add_child(cr)
+        cr.dialogue_done.connect(_on_critter_done, CONNECT_ONE_SHOT)
 
 func _on_critter_done() -> void:
 	critters_done += 1
@@ -149,8 +146,8 @@ func _on_photo_dialogue_done(_p) -> void:
 		_check_stage1_done()
 
 func _check_stage1_done() -> void:
-		if photo_dialogues_done == photos_total and critters_done == CRITTERS.size() and _current_critter == null:
-				_enter_stage2()
+                if photo_dialogues_done == photos_total and critters_done == CRITTERS.size():
+                                _enter_stage2()
 
 # ──────── STAGE 2 (mid panel → woman) ────────
 func _enter_stage2() -> void:
@@ -185,11 +182,14 @@ func _enter_stage3() -> void:
 
 # ──────── STAGE 4 (gold → river) ────────
 func _enter_stage4() -> void:
-	stage = Stage.STAGE4
-	CircleBank.hide_bank()
+        stage = Stage.STAGE4
+        CircleBank.hide_bank()
 
-	for ph in get_tree().get_nodes_in_group("photos"):
-		if ph.has_method("unlock_for_cleanup"): ph.unlock_for_cleanup()
+        for ph in get_tree().get_nodes_in_group("photos"):
+                if ph.has_method("unlock_for_cleanup"): ph.unlock_for_cleanup()
+
+        for cr in get_tree().get_nodes_in_group("critters"):
+                if cr.has_method("unlock_for_cleanup"): cr.unlock_for_cleanup()
 
 	var river := RIVER_SCENE.instantiate()
 	get_tree().current_scene.add_child(river)


### PR DESCRIPTION
## Summary
- Keep previously spawned critters instead of replacing them during Stage 1
- Mark critters as discardable and render them above photos
- Free all critters when entering Stage 4

## Testing
- `gdlint Scripts/Gameplay/Critter.gd Scripts/Gameplay/StageController.gd` *(fails: Unexpected token errors)*
- `apt-get install -y godot4` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689938e9f8a88327a2b0aabf51cedbf5