### PR TITLE
Keep critters around for stage 4 cleanup

### DIFF
--- a/Scenes/Critters/CritterBrouk.tscn
+++ b/Scenes/Critters/CritterBrouk.tscn
@@ -22,7 +22,7 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="Node2D" type="Area2D" groups=["wanderers"]]
+[node name="Node2D" type="Area2D" groups=["wanderers", "critters"]]
 top_level = true
 light_mask = 0
 visibility_layer = 2

--- a/Scenes/Critters/CritterJesterka.tscn
+++ b/Scenes/Critters/CritterJesterka.tscn
@@ -26,7 +26,7 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="Node2D" type="Area2D" groups=["wanderers"]]
+[node name="Node2D" type="Area2D" groups=["wanderers", "critters"]]
 top_level = true
 light_mask = 0
 visibility_layer = 2

--- a/Scenes/Critters/CritterKliste.tscn
+++ b/Scenes/Critters/CritterKliste.tscn
@@ -79,7 +79,7 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="Node2D" type="Area2D" groups=["wanderers"]]
+[node name="Node2D" type="Area2D" groups=["wanderers", "critters"]]
 top_level = true
 light_mask = 0
 visibility_layer = 2

--- a/Scenes/Critters/CritterList.tscn
+++ b/Scenes/Critters/CritterList.tscn
@@ -25,7 +25,7 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="Node2D" type="Area2D" groups=["wanderers"]]
+[node name="Node2D" type="Area2D" groups=["wanderers", "critters"]]
 top_level = true
 light_mask = 0
 visibility_layer = 2

--- a/Scenes/Critters/CritterSklenenka.tscn
+++ b/Scenes/Critters/CritterSklenenka.tscn
@@ -65,7 +65,7 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="Node2D" type="Area2D" groups=["wanderers"]]
+[node name="Node2D" type="Area2D" groups=["wanderers", "critters"]]
 top_level = true
 light_mask = 0
 visibility_layer = 2

--- a/Scenes/Critters/CritterSnek.tscn
+++ b/Scenes/Critters/CritterSnek.tscn
@@ -25,7 +25,7 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="Node2D" type="Area2D" groups=["wanderers"]]
+[node name="Node2D" type="Area2D" groups=["wanderers", "critters"]]
 top_level = true
 light_mask = 0
 visibility_layer = 2


### PR DESCRIPTION
## Summary
- Track critter instances in `StageController` and spawn them on a high-layer CanvasLayer so they remain above photos
- Mark critter scenes with a new `critters` group and enable critter cleanup by unlocking them in stage 4
- Allow critters to be dragged and discarded with a new `unlock_for_cleanup` routine

## Testing
- `godot3 --headless --check-only` *(fails: "config_version (5) is from a more recent and incompatible version of the engine")*


------
https://chatgpt.com/codex/tasks/task_e_68992f75ce3083278c07c2be9b25a449