### PR TITLE
Support portrait textures in dialogue

### DIFF
--- a/Data/Dialogue/Critters/brouk.json
+++ b/Data/Dialogue/Critters/brouk.json
@@ -1,4 +1,5 @@
 {
   "body": "I don't think you even like me.",
+  "portrait": "res://Assets/Critters/brouk.png",
   "choices": []
 }

--- a/Data/Dialogue/Critters/jesterka.json
+++ b/Data/Dialogue/Critters/jesterka.json
@@ -1,4 +1,5 @@
 {
-  "body": "1000× not a victim — a survivor.",
+  "body": "1000\u00d7 not a victim \u2014 a survivor.",
+  "portrait": "res://Assets/Critters/jesterka2.png",
   "choices": []
 }

--- a/Data/Dialogue/Critters/kliste.json
+++ b/Data/Dialogue/Critters/kliste.json
@@ -1,4 +1,5 @@
 {
   "body": "Sometimes, you wished I was dead, kicked in the head with a better aim this time.",
+  "portrait": "res://Assets/Critters/kliste.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Critters/list.json
+++ b/Data/Dialogue/Critters/list.json
@@ -1,4 +1,5 @@
 {
   "body": "sometimes I wish you were dead.",
+  "portrait": "res://Assets/Critters/list.png",
   "choices": []
 }

--- a/Data/Dialogue/Critters/sklenenka.json
+++ b/Data/Dialogue/Critters/sklenenka.json
@@ -1,4 +1,5 @@
 {
   "body": "The only truly happy childhood memories are the ones where you're not.",
+  "portrait": "res://Assets/Critters/sklenenka.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Critters/snek.json
+++ b/Data/Dialogue/Critters/snek.json
@@ -1,4 +1,5 @@
 {
   "body": "You had me ride the Horse, and this if anything made me feel very dispensable.",
+  "portrait": "res://Assets/Critters/snek.png",
   "choices": []
 }

--- a/Data/Dialogue/Photos/fetus_dialog.json
+++ b/Data/Dialogue/Photos/fetus_dialog.json
@@ -5,5 +5,6 @@
 		I will take care of another you in the best way I can. \n
 		And I will let go of the old you, the you that is falling behind, already blurred, disappearing.\n
 		Please go now.",
+  "portrait": "res://Assets/fetus.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_closure_dialog.json
+++ b/Data/Dialogue/Photos/mem_closure_dialog.json
@@ -3,6 +3,7 @@
   "body": 	"Not I am sorry, I love you. The most powerful, reparative words were said to me by a medical magazine:\n\n
 			Emotional neglect occurs when caregivers fail to provide the emotional support, validation, and attention children need during their formative years.\n\n
 			I have been coming back to it since then. A healing incantation. Do you know why I find it so beautiful?",
+  "portrait": "res://Assets/closure.jpg",
   "choices": [
 	{ "label": "1) I have been emotionally tortured in my own childhood.", "next": "mem_closure_reply1" },
 	{ "label": "2) I really can't take any more accusations.", "next": "mem_closure_reply1" }

--- a/Data/Dialogue/Photos/mem_closure_reply1.json
+++ b/Data/Dialogue/Photos/mem_closure_reply1.json
@@ -2,5 +2,6 @@
   "id": "mem_closure_dialog",
   "body": 	"I love this sentence because – I have always felt it was my fault that you didn't give me any love or care.\n\n 
 Things shifted after I read this. ",
+  "portrait": "res://Assets/closure.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_concept_dialog.json
+++ b/Data/Dialogue/Photos/mem_concept_dialog.json
@@ -1,6 +1,7 @@
 {
   "id": "mem_concept_dialog",
   "body": 	"There is a theorem of a good enough parent. Have you heard of it?",
+  "portrait": "res://Assets/concept.jpg",
   "choices": [
 	{ "label": "1) I don't want to talk mathematics right now.", "next": "mem_concept_reply1" },
 	{ "label": "2) You have no idea how hard everything was back then. You should be grateful that I even tried.", "next": "mem_concept_reply2" }

--- a/Data/Dialogue/Photos/mem_concept_reply1.json
+++ b/Data/Dialogue/Photos/mem_concept_reply1.json
@@ -5,6 +5,7 @@ if your reactions to your child’s needs == empathic in > 50% cases\n\n
 	then:  \n\n
 	you = good enough parent\n\n
 Fact: She learned very soon to hide all her needs for fear of upsetting you. ",
+  "portrait": "res://Assets/concept.jpg",
   "choices": [
 	{ "label": "1) You can just say it out loud, that I was a terrible mother.", "next": "mem_concept_reply1_1AND2_1" },
 	{ "label": "2) This is not useful for either of us. Are you aware of that?", "next": "" }

--- a/Data/Dialogue/Photos/mem_concept_reply1_1AND2_1.json
+++ b/Data/Dialogue/Photos/mem_concept_reply1_1AND2_1.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_concept_dialog",
   "body": 	"She doesn't want to blame you. She just really needs you to help Her understand.",
+  "portrait": "res://Assets/concept.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_concept_reply1_2AND2_2.json
+++ b/Data/Dialogue/Photos/mem_concept_reply1_2AND2_2.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_concept_dialog",
   "body": 	"",
+  "portrait": "res://Assets/concept.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_concept_reply2.json
+++ b/Data/Dialogue/Photos/mem_concept_reply2.json
@@ -4,6 +4,7 @@
 	then:  \n\n
 	you = good enough parent\n\n
 Fact: She learned very soon to hide all her needs for fear of upsetting you.",
+  "portrait": "res://Assets/concept.jpg",
   "choices": [
 	{ "label": "1) You can just say it out loud, that I was a terrible mother.", "next": "mem_concept_reply1_1AND2_1" },
 	{ "label": "2) This is not useful for either of us. Are you aware of that?", "next": "" }

--- a/Data/Dialogue/Photos/mem_crib_dialog.json
+++ b/Data/Dialogue/Photos/mem_crib_dialog.json
@@ -2,6 +2,7 @@
   "id": "mem_crib_dialog",
   "body": 	"The baby’s crying. Screaming in her crib. She’s so small. You have just fed her with a precisely measured dose of formula and changed her diaper. What more does she want? \n\n
 			What should you do?",
+  "portrait": "res://Assets/crib.jpg",
   "choices": [
 	{ "label": "1) Nothing", "next": "mem_crib_reply1" },
 	{ "label": "2) Something", "next": "mem_crib_reply2" }

--- a/Data/Dialogue/Photos/mem_crib_reply1.json
+++ b/Data/Dialogue/Photos/mem_crib_reply1.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_crib_dialog",
   "body": 	"In Korea they believe that a newborn baby does not actually cry. In an ancient language, it implores: 'Please save me.' You never even tried to. Why? Please help me understand.",
+  "portrait": "res://Assets/crib.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_crib_reply2.json
+++ b/Data/Dialogue/Photos/mem_crib_reply2.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_crib_dialog",
   "body": 	"You check The Book again. „Care for the mental development of the child at three months. If the baby still cries, after it has been fed and changed, it is not advisable to comfort it. We would be raising a selfish, spoiled child.“ I bought the book recently, hoping it will help me understand.",
+  "portrait": "res://Assets/crib.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_distance_dialog.json
+++ b/Data/Dialogue/Photos/mem_distance_dialog.json
@@ -2,6 +2,7 @@
   "id": "mem_distance_dialog",
   "body": 	"When you moved your family into the house on the edge of the forest, she was six and has already learned to avoid you as much as she could.\n\n 
 Where is she now? ",
+  "portrait": "res://Assets/distance.jpg",
   "choices": [
 	{ "label": "1) Playing in the garden mud.", "next": "mem_distance_reply1" },
 	{ "label": "2) Reading up on a tree", "next": "mem_distance_reply2" },

--- a/Data/Dialogue/Photos/mem_distance_reply1.json
+++ b/Data/Dialogue/Photos/mem_distance_reply1.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_distance_dialog",
   "body": 	"No, she’s not there. Where is the damn girl?",
+  "portrait": "res://Assets/distance.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_distance_reply2.json
+++ b/Data/Dialogue/Photos/mem_distance_reply2.json
@@ -1,6 +1,7 @@
 {
   "id": "mem_distance_dialog",
   "body": 	"The book is there but she’s not. Are you screaming her name now?",
+  "portrait": "res://Assets/distance.jpg",
   "choices": [
 	{ "label": "1) Yes.", "next": "mem_distance_reply2_1" },
 	{ "label": "2) No.", "next": "mem_distance_reply2_2" },

--- a/Data/Dialogue/Photos/mem_distance_reply2_1.json
+++ b/Data/Dialogue/Photos/mem_distance_reply2_1.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_closure1_dialog",
   "body": 	"Where the hell is she?",
+  "portrait": "res://Assets/distance.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_distance_reply2_2.json
+++ b/Data/Dialogue/Photos/mem_distance_reply2_2.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_closure1_dialog",
   "body": 	"The rage bubbles inside you. Where is she?",
+  "portrait": "res://Assets/distance.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_distance_reply3.json
+++ b/Data/Dialogue/Photos/mem_distance_reply3.json
@@ -1,6 +1,7 @@
 {
   "id": "mem_distance_dialog",
   "body": 	"She looks scared when she sees you. She looks so thin. Did she stop eating again? What are you thinking?",
+  "portrait": "res://Assets/distance.jpg",
   "choices": [
 	{ "label": "1) I need to force her into eating again.", "next": "mem_distance_reply3_1" },
 	{ "label": "2) The child-less years were the happiest of my life.", "next": "mem_distance_reply3_2" },

--- a/Data/Dialogue/Photos/mem_distance_reply3_1.json
+++ b/Data/Dialogue/Photos/mem_distance_reply3_1.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_distance_dialog",
   "body": 	"The violent attention I got for my silent self-harm really did scare me into eating again.",
+  "portrait": "res://Assets/distance.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_distance_reply3_2.json
+++ b/Data/Dialogue/Photos/mem_distance_reply3_2.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_distance_dialog",
   "body": 	"You will tell me that later, when I am sixteen.",
+  "portrait": "res://Assets/distance.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_hehory_dialog.json
+++ b/Data/Dialogue/Photos/mem_hehory_dialog.json
@@ -8,6 +8,7 @@ to the hospital.\n\n
 ...\n\n
 He fainted because of the blood. \n\n
 Just how much blood can spill from the head of a four-year old?",
+  "portrait": "res://Assets/hehory.jpg",
   "choices": [
 	{ "label": "1) I told Her to be careful around the Horse.", "next": "mem_hehory_reply1" },
 	{ "label": "2) Remain silent.", "next": "mem_hehory_reply2" }

--- a/Data/Dialogue/Photos/mem_hehory_reply1.json
+++ b/Data/Dialogue/Photos/mem_hehory_reply1.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_hehory_dialog",
   "body": 	"You always preferred the Horse to Her. All She was left with was a scar.",
+  "portrait": "res://Assets/hehory.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_hehory_reply2.json
+++ b/Data/Dialogue/Photos/mem_hehory_reply2.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_hehory_dialog",
   "body": 	"The hoof's impacted Her life in a way that it erased all the memories from before that summer's day in 1994. You never stopped loving and caring for that Horse and to this day you hold it dear in your memory.",
+  "portrait": "res://Assets/hehory.jpg",
   "choices": []
 }

--- a/Data/Dialogue/Photos/mem_repair_dialog.json
+++ b/Data/Dialogue/Photos/mem_repair_dialog.json
@@ -5,6 +5,7 @@ Not again, but for the first time.
 She got a copy of the Book that advised you against comforting the unhappy baby shrieking in her crib. 
 She used the cutout images for alchemical purposes, to see if the pain could be transformed into forgiveness.
 What do you think She was trying to achieve?",
+  "portrait": "res://Assets/repair.jpg",
   "choices": [
 	{ "label": "1) Confirmation of victimhood. To wear it, bathe in it, rub it into her skin.", "next": "mem_repair_reply1" },
 	{ "label": "2) I don’t think it’s a very good story when it doesn’t have my side in it. ", "next": "mem_repair_reply2" }

--- a/Data/Dialogue/Photos/mem_repair_reply1.json
+++ b/Data/Dialogue/Photos/mem_repair_reply1.json
@@ -1,6 +1,7 @@
 {
   "id": "mem_repair_dialog",
   "body": 	"Perhaps. By the way She read the book. There was no such advice. On the contrary, the authors encouraged parents to comfort their children and show them affection.",
+  "portrait": "res://Assets/repair.jpg",
   "choices": [
 	{ "label": "I wanted Her to be tough. Like me. Preferably without having to experience the same level of violence I did as a kid.", "next": "" },
 		]

--- a/Data/Dialogue/Photos/mem_repair_reply2.json
+++ b/Data/Dialogue/Photos/mem_repair_reply2.json
@@ -1,6 +1,7 @@
 {
   "id": "mem_repair_dialog",
   "body": 	"Your time will come. By the way She read the book. There was no such advice. On the contrary, the authors encouraged parents to comfort their children and show them affection.",
+  "portrait": "res://Assets/repair.jpg",
   "choices": [	
 	{ "label": "I wanted Her to be tough. Like me. Preferably without having to experience the same level of violence I did as a kid.", "next": "" },
 		]

--- a/Data/Dialogue/Photos/mem_repair_reply2_1AND1_1.json
+++ b/Data/Dialogue/Photos/mem_repair_reply2_1AND1_1.json
@@ -1,5 +1,6 @@
 {
   "id": "mem_repair_dialog",
   "body": 	"",
+  "portrait": "res://Assets/repair.jpg",
   "choices": []
 }

--- a/Scripts/UI/DialogueUI.gd
+++ b/Scripts/UI/DialogueUI.gd
@@ -98,9 +98,14 @@ func show_line(data: Dictionary) -> void:
 	if _body != null:
 		_body.text = body_text
 
-	var portrait_path_s: String = str(data.get("portrait", ""))
-	if _portrait != null:
-		_portrait.texture = (load(portrait_path_s) as Texture2D) if portrait_path_s != "" else null
+        var portrait_path_s: String = str(data.get("portrait", ""))
+        if _portrait != null:
+                if portrait_path_s != "":
+                        _portrait.texture = load(portrait_path_s) as Texture2D
+                        _portrait.visible = true
+                else:
+                        _portrait.texture = null
+                        _portrait.visible = false
 
 	# Choices
 	_clear_choices()


### PR DESCRIPTION
## Summary
- add `portrait` field to critter and photo dialogue JSON entries
- show and hide portrait texture in `DialogueUI` based on provided path

## Testing
- `godot3 --headless --path . -s Scripts/UI/DialogueUI.gd` *(fails: Can't open project, config_version 5 is from a more recent engine)*

------
https://chatgpt.com/codex/tasks/task_e_68992ff286bc832796963acd10c052e0