### PR TITLE
Keep critters after dialogue for cleanup

### DIFF
--- a/Scenes/Critters/CritterBrouk.tscn
+++ b/Scenes/Critters/CritterBrouk.tscn
@@ -26,7 +26,7 @@ animations = [{
 top_level = true
 light_mask = 0
 visibility_layer = 2
-z_index = 90
+z_index = 1000
 script = ExtResource("1_c02s6")
 one_liner_id = "Critters/brouk"
 

--- a/Scenes/Critters/CritterJesterka.tscn
+++ b/Scenes/Critters/CritterJesterka.tscn
@@ -30,7 +30,7 @@ animations = [{
 top_level = true
 light_mask = 0
 visibility_layer = 2
-z_index = 90
+z_index = 1000
 script = ExtResource("1_qecfm")
 one_liner_id = "Critters/jesterka"
 

--- a/Scenes/Critters/CritterKliste.tscn
+++ b/Scenes/Critters/CritterKliste.tscn
@@ -83,7 +83,7 @@ animations = [{
 top_level = true
 light_mask = 0
 visibility_layer = 2
-z_index = 90
+z_index = 1000
 script = ExtResource("1_dq6pa")
 one_liner_id = "Critters/kliste"
 

--- a/Scenes/Critters/CritterList.tscn
+++ b/Scenes/Critters/CritterList.tscn
@@ -29,7 +29,7 @@ animations = [{
 top_level = true
 light_mask = 0
 visibility_layer = 2
-z_index = 90
+z_index = 1000
 script = ExtResource("1_nq4vm")
 one_liner_id = "Critters/list"
 

--- a/Scenes/Critters/CritterSklenenka.tscn
+++ b/Scenes/Critters/CritterSklenenka.tscn
@@ -69,7 +69,7 @@ animations = [{
 top_level = true
 light_mask = 0
 visibility_layer = 2
-z_index = 90
+z_index = 1000
 script = ExtResource("1_ysoph")
 one_liner_id = "Critters/sklenenka"
 

--- a/Scenes/Critters/CritterSnek.tscn
+++ b/Scenes/Critters/CritterSnek.tscn
@@ -29,7 +29,7 @@ animations = [{
 top_level = true
 light_mask = 0
 visibility_layer = 2
-z_index = 90
+z_index = 1000
 script = ExtResource("1_v487x")
 one_liner_id = "Critters/snek"
 

--- a/Scripts/Gameplay/Critter.gd
+++ b/Scripts/Gameplay/Critter.gd
@@ -18,10 +18,9 @@ var _triggered   : bool = false
 
 # ───────── READY ─────────
 func _ready() -> void:
-		add_to_group("critters")
-		add_to_group("discardable")
-		z_index = 10000
-		z_as_relative = false
+                add_to_group("critters")
+                z_index = 10000
+                z_as_relative = false
 
 		vp.size_changed.connect(_on_viewport_resized)
 		_refresh_view_rect()
@@ -122,13 +121,14 @@ func _on_trigger_anim_finished(_anim:String) -> void:
 		sprite.play("move")
 
 func _on_dialogue_finished(last_id: String) -> void:
-	# Ignore unrelated dialogues if multiple critters/photos can trigger
-	if last_id != one_liner_id:
-		return
-	_triggered = false
-	sprite.play("move")
-	emit_signal("dialogue_done")
+        # Ignore unrelated dialogues if multiple critters/photos can trigger
+        if last_id != one_liner_id:
+                return
+        _triggered = false
+        sprite.play("move")
+        add_to_group("gold")
+        emit_signal("dialogue_done")
 
 # ───────── CLEANUP ─────────
 func unlock_for_cleanup() -> void:
-	queue_free()
+        pass

--- a/Scripts/Gameplay/StageController.gd
+++ b/Scripts/Gameplay/StageController.gd
@@ -128,17 +128,18 @@ func _enter_stage1() -> void:
 		_spawn_next_critter()
 
 func _spawn_next_critter() -> void:
-	if _queue.is_empty():
-		_check_stage1_done()
-		return
-	var cr: Node = (_queue.pop_back() as PackedScene).instantiate()
-	get_tree().current_scene.add_child(cr)
-	cr.dialogue_done.connect(_on_critter_done, CONNECT_ONE_SHOT)
+        if _queue.is_empty():
+                _check_stage1_done()
+                return
+        var cr: Node = (_queue.pop_back() as PackedScene).instantiate()
+        get_tree().current_scene.add_child(cr)
+        cr.dialogue_done.connect(Callable(self, "_on_critter_done").bind(cr), CONNECT_ONE_SHOT)
 
-func _on_critter_done() -> void:
-	critters_done += 1
-	_spawn_next_critter()        # continue queue
-	_check_stage1_done()
+func _on_critter_done(cr: Node) -> void:
+        critters_done += 1
+        cr.add_to_group("discardable")
+        _spawn_next_critter()        # continue queue
+        _check_stage1_done()
 
 func _on_photo_dialogue_done(_p) -> void:
 		if stage != Stage.STAGE1: return


### PR DESCRIPTION
## Summary
- Retain spawned critters and tag them as `discardable` when their dialogue ends.
- Critters mark themselves `gold` and no longer self-free, allowing TrashCan cleanup.
- Set high `z_index` on critter scenes so they display above photos.

## Testing
- `godot3 --headless --path . --quit` *(fails: project requires newer engine config version)*

------
https://chatgpt.com/codex/tasks/task_e_689943fa6b4483279c710d67b711b995