### PR TITLE
Use one-shot dialogue connections for photos

### DIFF
--- a/Scripts/Gameplay/Photo.gd
+++ b/Scripts/Gameplay/Photo.gd
@@ -141,37 +141,27 @@ func _snap_to_slot(slot: Area2D, mem_id: String) -> void:
 #  Dialogue trigger
 # ───────────────────────────
 func _start_dialogue_if_possible() -> void:
-		if _dialogue_complete:
-				return
-		if dialog_id == "":
-				_dialogue_complete = true
-				return
-		if Engine.is_editor_hint():
-				return
-		if not DialogueManager.has_method("start"):
-				_dialogue_complete = true
-				emit_signal("dialogue_done", self)
-				return
-		DialogueManager.dialogue_finished.connect(_on_dialogue_finished)
-		DialogueManager.start(dialog_id)
+                if _dialogue_complete:
+                                return
+                if dialog_id == "":
+                                _dialogue_complete = true
+                                return
+                if Engine.is_editor_hint():
+                                return
+                if not DialogueManager.has_method("start"):
+                                _dialogue_complete = true
+                                emit_signal("dialogue_done", self)
+                                return
+                DialogueManager.dialogue_finished.connect(_on_dialogue_finished, flags=CONNECT_ONE_SHOT)
+                DialogueManager.start(dialog_id)
 
 func _on_dialogue_finished(last_id: String) -> void:
-	if last_id != dialog_id:
-		return
-	if DialogueManager.dialogue_finished.is_connected(_on_dialogue_finished):
-		DialogueManager.dialogue_finished.disconnect(_on_dialogue_finished)
-	if _dialogue_complete:
-		return
-	_dialogue_complete = true
-	emit_signal("dialogue_done", self)
-	if dialog_id == "":
-			return
-	if Engine.is_editor_hint():
-			return
-	if not DialogueManager.has_method("start"):
-					return
-	DialogueManager.dialogue_finished.connect(_on_dialogue_finished)
-	DialogueManager.start(dialog_id)
+        if last_id != dialog_id:
+                return
+        if _dialogue_complete:
+                return
+        _dialogue_complete = true
+        emit_signal("dialogue_done", self)
 # ───────────────────────────
 #  Helpers
 # ───────────────────────────


### PR DESCRIPTION
## Summary
- Auto-disconnect photo dialogue callbacks using `CONNECT_ONE_SHOT`
- Remove redundant reconnect and restart logic after a photo dialogue completes

## Testing
- `godot3 --headless --path . -q` *(fails: Can't open project at '/workspace/PLSHLP/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_689955432ce483279233f9bc28d44f27