### PR TITLE
Add CircleBank reload method and refresh after reset

### DIFF
--- a/Scripts/Gameplay/CircleBank.gd
+++ b/Scripts/Gameplay/CircleBank.gd
@@ -31,8 +31,9 @@ func _late_init() -> void:
 
 # ───────── data setup ─────────
 func _cache_slots() -> void:
-	for s : Node in get_tree().get_nodes_in_group("memory_slots"):
-		_mem2slot[s.memory_id] = s
+        _mem2slot.clear()
+        for s : Node in get_tree().get_nodes_in_group("memory_slots"):
+                _mem2slot[s.memory_id] = s
 
 func _resolve_origin() -> Vector2:
 	if origin_path != NodePath(""):
@@ -99,10 +100,11 @@ func _mems_for_photo(p:Node) -> Array[String]:
 	return out
 
 func _apply_pulse(spr:Sprite2D, mem_id:String) -> void:
-	var slot : Node2D = _mem2slot.get(mem_id)
-	if slot == null: return
-	var dist : float = _active_photo.global_position.distance_to(slot.global_position)
-	var t    : float = clamp(1.0 - dist / max_dist, 0.0, 1.0)
+        var slot : Node2D = _mem2slot.get(mem_id)
+        if slot == null or not is_instance_valid(slot):
+                return
+        var dist : float = _active_photo.global_position.distance_to(slot.global_position)
+        var t    : float = clamp(1.0 - dist / max_dist, 0.0, 1.0)
 
 	spr.scale    = Vector2.ONE * lerp(1.0, max_scale, t)
 	spr.modulate = _base_mod[mem_id].lerp(pulse_tint, t)
@@ -119,6 +121,10 @@ func _reset_all() -> void:
 func show_bank():  visible = true
 func hide_bank():  visible = false
 func reset_all() -> void:
-	for spr : Sprite2D in _icons.values():
-		spr.visible = true
-	_reset_all()
+        for spr : Sprite2D in _icons.values():
+                spr.visible = true
+        _reset_all()
+
+func reload() -> void:
+        _cache_slots()
+        _build_icons()

--- a/Scripts/Gameplay/StageController.gd
+++ b/Scripts/Gameplay/StageController.gd
@@ -219,10 +219,10 @@ func _enter_end() -> void:
 
 # ──────── RESET ────────
 func reset() -> void:
-		stage = Stage.INTRO
-		photo_dialogues_done = 0
-		photos_total = 0
-		critters_done = 0
+                stage = Stage.INTRO
+                photo_dialogues_done = 0
+                photos_total = 0
+                critters_done = 0
 
 		_queue.clear()
 		if woman:
@@ -235,10 +235,12 @@ func reset() -> void:
 		gameplay = null
 		overlay = null
 
-		MemoryPool.init_from_table(memory_table)
-		CircleBank.reset_all()
+                MemoryPool.init_from_table(memory_table)
+                CircleBank.reset_all()
 
-		get_tree().change_scene_to_file("res://Scenes/Main.tscn")
+                get_tree().change_scene_to_file("res://Scenes/Main.tscn")
+                await get_tree().process_frame
+                CircleBank.reload()
 
 # ──────── helpers ────────
 func _clear_overlay() -> void:


### PR DESCRIPTION
## Summary
- Clear CircleBank slot map before caching slots
- Validate slot instances during pulse updates
- Add CircleBank.reload and invoke it from StageController.reset

## Testing
- `sudo apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `godot4 --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899a8ae4ef88327a7549e66e21bb855