### PR TITLE
Ensure CircleBank icons reset on stage restart

### DIFF
--- a/Scripts/Gameplay/CircleBank.gd
+++ b/Scripts/Gameplay/CircleBank.gd
@@ -125,6 +125,16 @@ func reset_all() -> void:
                 spr.visible = true
         _reset_all()
 
+func clear() -> void:
+        for spr : Sprite2D in _icons.values():
+                if is_instance_valid(spr):
+                        spr.queue_free()
+        _icons.clear()
+        _base_mod.clear()
+        _mem2slot.clear()
+        _active_photo = null
+
 func reload() -> void:
+        clear()
         _cache_slots()
         _build_icons()

--- a/Scripts/Gameplay/StageController.gd
+++ b/Scripts/Gameplay/StageController.gd
@@ -235,12 +235,12 @@ func reset() -> void:
 		gameplay = null
 		overlay = null
 
-                MemoryPool.init_from_table(memory_table)
-                CircleBank.reset_all()
+		MemoryPool.init_from_table(memory_table)
+		CircleBank.clear()
 
-                get_tree().change_scene_to_file("res://Scenes/Main.tscn")
-                await get_tree().process_frame
-                CircleBank.reload()
+		get_tree().change_scene_to_file("res://Scenes/Main.tscn")
+		await get_tree().process_frame
+		CircleBank.reload()
 
 # ──────── helpers ────────
 func _clear_overlay() -> void:


### PR DESCRIPTION
## Summary
- add `CircleBank.clear()` to remove existing icons and reset state
- call `clear()` before reloading icons and when resetting the stage

## Testing
- `godot3-server --check Scripts/Gameplay/CircleBank.gd && godot3-server --check Scripts/Gameplay/StageController.gd` *(fails: `config_version (5) is from a more recent and incompatible version of the engine`)*

------
https://chatgpt.com/codex/tasks/task_e_6899b66e15ec8327b3cb4412df461413