### PR TITLE
Use controller tree in Stage4State cleanup

### DIFF
--- a/Scripts/Gameplay/Stages/Stage4State.gd
+++ b/Scripts/Gameplay/Stages/Stage4State.gd
@@ -1,18 +1,20 @@
-extends StageState
 class_name Stage4State
+extends StageState
 
 const RIVER_SCENE := preload("res://Scenes/River.tscn")
 
 func enter(controller) -> void:
     CircleBank.hide_bank()
-    for ph in get_tree().get_nodes_in_group("photos"):
+    for ph in controller.get_tree().get_nodes_in_group("photos"):
         if ph.has_method("unlock_for_cleanup"): ph.unlock_for_cleanup()
-    for cr in get_tree().get_nodes_in_group("critters"):
+    for cr in controller.get_tree().get_nodes_in_group("critters"):
         if cr.has_method("unlock_for_cleanup"): cr.unlock_for_cleanup()
     var river := RIVER_SCENE.instantiate()
-    get_tree().current_scene.add_child(river)
-    river.global_position = (controller._river_pos.global_position if controller._river_pos else Vector2(640,720))
+    controller.get_tree().current_scene.add_child(river)
+    river.global_position = (
+        controller._river_pos.global_position if controller._river_pos else Vector2(640, 720)
+    )
     river.cleanup_complete.connect(func(): finished.emit(OutroState.new()))
 
-func exit(controller) -> void:
+func exit(_controller) -> void:
     pass


### PR DESCRIPTION
## Summary
- replace direct `get_tree` calls with `controller.get_tree` in Stage4State cleanup and river spawning
- tidy Stage4State definitions and formatting to satisfy linter

## Testing
- `gdlint Scripts/Gameplay/Stages/Stage4State.gd`

------
https://chatgpt.com/codex/tasks/task_e_689a142e23208327a3d1d1291d4ffd07