### PR TITLE
Use controller's tree when spawning Stage 3 fetus

### DIFF
--- a/Scripts/Gameplay/Stages/Stage3State.gd
+++ b/Scripts/Gameplay/Stages/Stage3State.gd
@@ -8,9 +8,9 @@ func enter(controller) -> void:
     controller.woman.create_tween().tween_property(controller.woman, "global_position", dest, 0.8).set_trans(Tween.TRANS_SINE)
     controller.woman.create_tween().tween_property(controller.woman, "scale", Vector2.ONE * 0.3, 0.8)
 
-    await get_tree().create_timer(0.8).timeout
+    await controller.get_tree().create_timer(0.8).timeout
     controller.fetus = FETUS_SCENE.instantiate()
-    get_tree().current_scene.add_child(controller.fetus)
+    controller.get_tree().current_scene.add_child(controller.fetus)
     controller.fetus.global_position = (controller._fetus_spawn.global_position if controller._fetus_spawn else Vector2.ZERO)
     controller.fetus.center_pos      = controller._fetus_centre.global_position
     AudioManager.play_sfx(controller.heartbeat_sfx)


### PR DESCRIPTION
## Summary
- Use controller's tree for Stage 3 timer and fetus instantiation

## Testing
- `godot4 --headless --check Scripts/Gameplay/Stages/Stage3State.gd` *(fails: Could not find type "MemoryTable" and other missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_689a142b34848327ae663adad07f0c05