### PR TITLE
Refactor stage states to avoid direct tree access

### DIFF
--- a/Scripts/Gameplay/Stages/IntroState.gd
+++ b/Scripts/Gameplay/Stages/IntroState.gd
@@ -1,0 +1,46 @@
+extends StageState
+class_name IntroState
+
+const PARENT_PANEL     := preload("res://Scenes/Overlays/ParentChoicePanel.tscn")
+const DIFFICULTY_PANEL := preload("res://Scenes/Overlays/DifficultyChoicePanel.tscn")
+const INTRO_PANEL      := preload("res://Scenes/Overlays/IntroPanel.tscn")
+
+func enter(controller) -> void:
+    var parent: Node = PARENT_PANEL.instantiate()
+    controller.overlay.add_child(parent)
+    parent.parent_chosen.connect(_on_parent_decided.bind(controller))
+
+func exit(controller) -> void:
+    controller._clear_overlay()
+
+func _on_parent_decided(is_parent: bool, controller) -> void:
+    controller._clear_overlay()
+    if is_parent:
+        var alt: Node = controller.alt_intro_scene.instantiate()
+        controller.overlay.add_child(alt)
+        alt.intro_finished.connect(func(): controller.get_tree().quit())
+    else:
+        _show_difficulty(controller)
+
+func _show_difficulty(controller) -> void:
+    var d: Node = DIFFICULTY_PANEL.instantiate()
+    controller.overlay.add_child(d)
+    d.difficulty_chosen.connect(_on_diff_selected.bind(controller))
+
+func _on_diff_selected(easy: bool, controller) -> void:
+    _apply_slot_cfg(controller, controller.easy_slots_json if easy else controller.hard_slots_json)
+    controller._clear_overlay()
+    var intro: Node = INTRO_PANEL.instantiate()
+    controller.overlay.add_child(intro)
+    intro.intro_finished.connect(func(): finished.emit(Stage1State.new()))
+
+func _apply_slot_cfg(controller, path: String) -> void:
+    if path.is_empty() or not FileAccess.file_exists(path):
+        return
+    var j := JSON.new()
+    if j.parse(FileAccess.get_file_as_string(path)) != OK:
+        return
+    for n in j.data:
+        var ph: Photo = controller.get_tree().current_scene.find_child(n, true, false) as Photo
+        if ph:
+            ph.allowed_slots = PackedInt32Array(j.data[n])

--- a/Scripts/Gameplay/Stages/OutroState.gd
+++ b/Scripts/Gameplay/Stages/OutroState.gd
@@ -1,0 +1,10 @@
+extends StageState
+class_name OutroState
+
+func enter(controller) -> void:
+    if DialogueManager.is_active():
+        await DialogueManager.dialogue_finished
+    DialogueManager.start("outro")
+
+func exit(controller) -> void:
+    pass

--- a/Scripts/Gameplay/Stages/Stage1State.gd
+++ b/Scripts/Gameplay/Stages/Stage1State.gd
@@ -1,0 +1,59 @@
+extends StageState
+class_name Stage1State
+
+const CRITTERS : Array[PackedScene] = [
+    preload("res://Scenes/Critters/CritterJesterka.tscn"),
+    preload("res://Scenes/Critters/CritterBrouk.tscn"),
+    preload("res://Scenes/Critters/CritterList.tscn"),
+    preload("res://Scenes/Critters/CritterSklenenka.tscn"),
+    preload("res://Scenes/Critters/CritterSnek.tscn"),
+    preload("res://Scenes/Critters/CritterKliste.tscn")
+]
+
+var photo_dialogues_done : int = 0
+var photos_total   : int = 0
+var critters_done  : int = 0
+var _queue : Array[PackedScene] = []
+
+func enter(controller) -> void:
+    controller.gameplay.visible = true
+    CircleBank.reset_all(); CircleBank.show_bank()
+    photo_dialogues_done = 0
+    critters_done = 0
+    photos_total = 0
+    for ph in controller.get_tree().get_nodes_in_group("photos"):
+        var pid: String = ph.dialog_id
+        if pid != "":
+            photos_total += 1
+    _queue = CRITTERS.duplicate()
+    _queue.shuffle()
+    _spawn_next_critter(controller)
+
+func exit(controller) -> void:
+    pass
+
+func _spawn_next_critter(controller) -> void:
+    if _queue.is_empty():
+        _check_stage1_done(controller)
+        return
+    var cr: Node = (_queue.pop_back() as PackedScene).instantiate()
+    if controller.critter_layer:
+        controller.critter_layer.add_child(cr)
+    else:
+        controller.get_tree().current_scene.add_child(cr)
+    cr.dialogue_done.connect(controller._on_critter_dialogue_done.bind(cr))
+
+func on_photo_dialogue_done(controller, _photo) -> void:
+    photo_dialogues_done += 1
+    _check_stage1_done(controller)
+
+func on_critter_dialogue_done(controller, critter) -> void:
+    critters_done += 1
+    if is_instance_valid(critter):
+        critter.add_to_group("discardable")
+    _spawn_next_critter(controller)
+    _check_stage1_done(controller)
+
+func _check_stage1_done(controller) -> void:
+    if photo_dialogues_done == photos_total and critters_done == CRITTERS.size():
+        finished.emit(Stage2State.new())

--- a/Scripts/Gameplay/Stages/Stage2State.gd
+++ b/Scripts/Gameplay/Stages/Stage2State.gd
@@ -1,0 +1,21 @@
+extends StageState
+class_name Stage2State
+
+const WOMAN_SCENE := preload("res://Scenes/WomanPhoto.tscn")
+
+func enter(controller) -> void:
+    controller._clear_overlay()
+    var mid: Node = controller.mid_stage_panel.instantiate()
+    controller.overlay.add_child(mid)
+    mid.intro_finished.connect(func(): _spawn_woman(controller))
+
+func exit(controller) -> void:
+    controller._clear_overlay()
+
+func _spawn_woman(controller) -> void:
+    controller._clear_overlay()
+    var stack: Node = controller._fetch_node(controller.stack_path, "PhotoStack")
+    controller.woman = WOMAN_SCENE.instantiate()
+    stack.add_child(controller.woman)
+    controller.woman.global_position = controller._woman_spawn.global_position if controller._woman_spawn else Vector2(150,150)
+    controller.woman.all_words_transformed.connect(func(): finished.emit(Stage3State.new()))

--- a/Scripts/Gameplay/Stages/Stage3State.gd
+++ b/Scripts/Gameplay/Stages/Stage3State.gd
@@ -1,0 +1,20 @@
+extends StageState
+class_name Stage3State
+
+const FETUS_SCENE := preload("res://Scenes/FetusPhoto.tscn")
+
+func enter(controller) -> void:
+    var dest: Vector2 = controller._woman_target.global_position if controller._woman_target else Vector2(100,100)
+    controller.woman.create_tween().tween_property(controller.woman, "global_position", dest, 0.8).set_trans(Tween.TRANS_SINE)
+    controller.woman.create_tween().tween_property(controller.woman, "scale", Vector2.ONE * 0.3, 0.8)
+
+    await controller.get_tree().create_timer(0.8).timeout
+    controller.fetus = FETUS_SCENE.instantiate()
+    controller.get_tree().current_scene.add_child(controller.fetus)
+    controller.fetus.global_position = (controller._fetus_spawn.global_position if controller._fetus_spawn else Vector2.ZERO)
+    controller.fetus.center_pos      = controller._fetus_centre.global_position
+    AudioManager.play_sfx(controller.heartbeat_sfx)
+    controller.fetus.dialogue_done.connect(func(): finished.emit(Stage4State.new()))
+
+func exit(controller) -> void:
+    pass

--- a/Scripts/Gameplay/Stages/Stage4State.gd
+++ b/Scripts/Gameplay/Stages/Stage4State.gd
@@ -1,0 +1,18 @@
+extends StageState
+class_name Stage4State
+
+const RIVER_SCENE := preload("res://Scenes/River.tscn")
+
+func enter(controller) -> void:
+    CircleBank.hide_bank()
+    for ph in controller.get_tree().get_nodes_in_group("photos"):
+        if ph.has_method("unlock_for_cleanup"): ph.unlock_for_cleanup()
+    for cr in controller.get_tree().get_nodes_in_group("critters"):
+        if cr.has_method("unlock_for_cleanup"): cr.unlock_for_cleanup()
+    var river: Node = RIVER_SCENE.instantiate()
+    controller.get_tree().current_scene.add_child(river)
+    river.global_position = (controller._river_pos.global_position if controller._river_pos else Vector2(640,720))
+    river.cleanup_complete.connect(func(): finished.emit(OutroState.new()))
+
+func exit(controller) -> void:
+    pass

--- a/Scripts/Gameplay/Stages/StageState.gd
+++ b/Scripts/Gameplay/Stages/StageState.gd
@@ -1,0 +1,16 @@
+extends RefCounted
+class_name StageState
+
+signal finished(new_state: StageState)
+
+func enter(controller) -> void:
+    pass
+
+func exit(controller) -> void:
+    pass
+
+func on_photo_dialogue_done(controller, photo) -> void:
+    pass
+
+func on_critter_dialogue_done(controller, critter) -> void:
+    pass


### PR DESCRIPTION
## Summary
- Type Stage2State variables and spawn logic
- Route all stage scripts' tree operations through the controller
- Annotate auxiliary nodes for clarity

## Testing
- `godot --version` *(command not found)*
- `apt-get install -y godot` *(package not found)*


------
https://chatgpt.com/codex/tasks/task_e_689a10ab0f248327aec77c4e659fd9e6